### PR TITLE
[Feat/#20] 바텀시트 공통 컴포넌트 생성

### DIFF
--- a/packages/design-system/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/design-system/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { BottomSheet } from "./BottomSheet";
+
+const meta: Meta<typeof BottomSheet> = {
+  title: "Components/BottomSheet",
+  component: BottomSheet,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BottomSheet>;
+
+const DefaultTemplate = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="relative h-screen bg-gray-100">
+      {!open && (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="absolute left-1/2 top-10 -translate-x-1/2 rounded-[1rem] bg-primary px-[1.6rem] py-[0.8rem] body2-m text-inverse"
+        >
+          바텀시트 다시 열기
+        </button>
+      )}
+
+      <BottomSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        variant="default"
+        overlay
+      >
+        <div className="body1-m text-default">
+          일반 바텀시트입니다.
+        </div>
+      </BottomSheet>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <DefaultTemplate />,
+};
+
+const MapTemplate = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="relative h-screen bg-gray-100">
+      {!open && (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="absolute left-1/2 top-10 -translate-x-1/2 rounded-[1rem] bg-primary px-[1.6rem] py-[0.8rem] body2-m text-inverse"
+        >
+          바텀시트 다시 열기
+        </button>
+      )}
+
+      <BottomSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        variant="map"
+        overlay={false}
+      >
+        <div className="flex flex-col gap-[1.6rem]">
+          <div className="flex items-center gap-[0.8rem]">
+            <span className="body1-m text-default">📍 별동네 베이커리카페 별내본점</span>
+          </div>
+
+          <div className="h-[20rem] rounded-[1rem] bg-gray-100" />
+        </div>
+      </BottomSheet>
+    </div>
+  );
+};
+
+export const MapDetail: Story = {
+  render: () => <MapTemplate />,
+};

--- a/packages/design-system/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/design-system/src/components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,75 @@
+import { cn } from "../../libs";
+import type { BottomSheetProps, BottomSheetVariant } from "./BottomSheet.types";
+
+const BOTTOM_SHEET_VARIANT_CLASSES: Record<BottomSheetVariant, string> = {
+  default: "rounded-t-[2rem] bg-inverse",
+  map: "rounded-t-[2rem] bg-inverse",
+};
+
+export const BottomSheet = ({
+  open,
+  onClose,
+  children,
+  variant = "default",
+  closeOnOverlayClick = true,
+  showHandle = true,
+  overlay = true,
+  className,
+  overlayClassName,
+  contentClassName,
+  handleClassName,
+}: BottomSheetProps) => {
+  if (!open) {
+    return null;
+  }
+
+  const handleOverlayClick = () => {
+    if (!closeOnOverlayClick) {
+      return;
+    }
+
+    onClose();
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-9999 flex items-end justify-center",
+        overlay ? "bg-black/50" : "bg-transparent",
+        overlayClassName
+      )}
+      onClick={handleOverlayClick}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          "w-full border-x border-t border-primary shadow-[0_-4px_4px_rgba(0,0,0,0.1)]",
+          BOTTOM_SHEET_VARIANT_CLASSES[variant],
+          className
+        )}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div
+          className={cn(
+            "px-[1rem] pt-[0.8rem] pb-[2rem]",
+            contentClassName
+          )}
+        >
+          {showHandle && (
+            <div
+              className={cn(
+                "flex w-full justify-center py-[0.8rem]",
+                handleClassName
+              )}
+            >
+              <div className="h-[0.3rem] w-[7rem] rounded-full bg-gray-300" />
+            </div>
+          )}
+
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/design-system/src/components/BottomSheet/BottomSheet.types.ts
+++ b/packages/design-system/src/components/BottomSheet/BottomSheet.types.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+export type BottomSheetVariant = "default" | "map";
+
+export interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  variant?: BottomSheetVariant;
+  closeOnOverlayClick?: boolean;
+  showHandle?: boolean;
+  overlay?: boolean;
+  className?: string;
+  overlayClassName?: string;
+  contentClassName?: string;
+  handleClassName?: string;
+}

--- a/packages/design-system/src/components/BottomSheet/index.ts
+++ b/packages/design-system/src/components/BottomSheet/index.ts
@@ -1,0 +1,2 @@
+export { BottomSheet } from "./BottomSheet";
+export type { BottomSheetProps, BottomSheetVariant } from "./BottomSheet.types";


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
- 공통 `BottomSheet` 컴포넌트를 패키지에 추가했습니다.
- 오버레이 유무를 옵션으로 분리해 일반 바텀시트와 지도용 바텀시트를 모두 대응할 수 있도록 구성했습니다.
- 상단 핸들, 내부 패딩, 테두리, 그림자 등 공통 스타일을 적용했습니다.
- 오버레이 또는 바깥 영역 클릭 시 닫히도록 동작을 구현했습니다.

> 작업한 내용을 체크해주세요.
- [x] BottomSheet 공통 컴포넌트 추가
- [x] overlay 옵션 분기 처리
- [x] 공통 스타일 적용
- [x] Storybook 스토리 작성

## 🚀 설계 의도 및 개선점
- 바텀시트 UI를 화면별로 중복 구현하지 않도록 공통 컴포넌트로 분리했습니다.
- 지도 상세용과 일반용의 차이를 `overlay` 옵션으로 처리해 재사용성을 높였습니다.
- 초기에는 드래그 닫기 방식도 검토했지만, 사용성과 안정성을 고려해 클릭 닫기 방식으로 단순화했습니다.

### 📸 스크린샷 (선택)
- BottomSheet 기본형
- 지도 상세형 BottomSheet

### 📎 기타 참고사항
- Storybook에서 기본형 / 지도형 각각 확인 가능합니다.
- 환경 변수 변경은 없습니다.

Fixes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * BottomSheet 컴포넌트를 디자인 시스템에 추가했습니다. 기본 및 맵 두 가지 변형을 지원하며, 오버레이 제어, 드래그 핸들, 닫기 기능 등을 포함합니다.
  * Storybook 스토리를 통해 각 변형의 사용 예시를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->