### PR TITLE
[Feat/#27] Tag 공통 컴포넌트 생성

### DIFF
--- a/packages/design-system/src/components/Tag/Tag.stories.tsx
+++ b/packages/design-system/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Tag } from "./Tag";
+
+const meta = {
+  title: "Components/Tag",
+  component: Tag,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="flex flex-wrap items-center gap-3 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["pill", "pill-wide", "pill-static", "rounded-rect"],
+    },
+    selected: {
+      control: "boolean",
+    },
+    changeOnClick: {
+      control: "boolean",
+    },
+  },
+} satisfies Meta<typeof Tag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PillDefault: Story = {
+  args: {
+    children: "기본 태그",
+    variant: "pill",
+    selected: false,
+    changeOnClick: true,
+  },
+};
+
+export const PillSelected: Story = {
+  args: {
+    children: "선택된 태그",
+    variant: "pill",
+    selected: true,
+    changeOnClick: true,
+  },
+};
+
+export const PillWideDefault: Story = {
+  args: {
+    children: "작은 태그",
+    variant: "pill-wide",
+    selected: false,
+    changeOnClick: true,
+  },
+};
+
+export const PillWideSelected: Story = {
+  args: {
+    children: "작은 태그 선택",
+    variant: "pill-wide",
+    selected: true,
+    changeOnClick: true,
+  },
+};
+
+export const PillStatic: Story = {
+  args: {
+    children: "고정 태그",
+    variant: "pill-static",
+    selected: false,
+    changeOnClick: false,
+  },
+};
+
+export const RoundedRect: Story = {
+  args: {
+    children: "사각 태그",
+    variant: "rounded-rect",
+    selected: false,
+    changeOnClick: false,
+  },
+};

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -1,0 +1,59 @@
+import { cn } from "../../libs";
+import type { TagProps } from "./Tag.types";
+
+const variantClassMap = {
+  pill: {
+    base: "rounded-full border border-primary px-[1rem] py-[0.6rem] text-primary",
+    selected: "bg-primary text-inverse border-primary",
+    unselected: "bg-transparent text-primary",
+  },
+  "pill-wide": {
+    base: "rounded-full border border-primary px-[1.6rem] py-[0.6rem] text-primary",
+    selected: "bg-primary text-inverse border-primary",
+    unselected: "bg-transparent text-primary",
+  },
+  "pill-static": {
+    base: "rounded-full border border-primary px-[1rem] py-[0.6rem] text-primary bg-transparent",
+    selected: "text-primary bg-transparent border-primary",
+    unselected: "text-primary bg-transparent border-primary",
+  },
+  "rounded-rect": {
+    base: "rounded-[10px] border border-primary px-[2rem] py-[0.8rem] text-primary bg-transparent",
+    selected: "text-primary bg-transparent border-primary",
+    unselected: "text-primary bg-transparent border-primary",
+  },
+} as const;
+
+export const Tag = ({
+  children,
+  variant = "pill",
+  selected = false,
+  changeOnClick = true,
+  className,
+  type = "button",
+  disabled = false,
+  ...props
+}: TagProps) => {
+  const styles = variantClassMap[variant];
+
+  const isSelectableVariant = variant === "pill" || variant === "pill-wide";
+  const shouldApplySelectedStyle =
+    isSelectableVariant && changeOnClick && selected;
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap text-sm font-medium leading-none transition-colors",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        styles.base,
+        shouldApplySelectedStyle ? styles.selected : styles.unselected,
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/design-system/src/components/Tag/Tag.types.ts
+++ b/packages/design-system/src/components/Tag/Tag.types.ts
@@ -1,0 +1,35 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type TagVariant =
+  | "pill"
+  | "pill-wide"
+  | "pill-static"
+  | "rounded-rect";
+
+export interface TagProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  children: ReactNode;
+
+  /**
+   * 태그 스타일 종류
+   * - pill: 기본 선택형 태그
+   * - pill-wide: 좌우 패딩이 더 넓은 선택형 태그
+   * - pill-static: 선택 변화 없는 고정형 태그
+   * - rounded-rect: radius 10의 사각형 태그
+   */
+  variant?: TagVariant;
+
+  /**
+   * 현재 선택 상태
+   * 선택형 태그에서만 의미 있음
+   */
+  selected?: boolean;
+
+  /**
+   * 클릭 시 selected 스타일 변화 허용 여부
+   * false면 눌러도 스타일 변화 없음
+   */
+  changeOnClick?: boolean;
+
+  className?: string;
+}

--- a/packages/design-system/src/components/Tag/index.ts
+++ b/packages/design-system/src/components/Tag/index.ts
@@ -1,0 +1,2 @@
+export { Tag } from "./Tag";
+export type { TagProps, TagVariant } from "./Tag.types";

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -3,3 +3,4 @@ export * from "./Input";
 export * from "./Modal";
 export * from "./BottomSheet";
 export * from "./Card";
+export * from "./Tag";


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
- 디자인 시스템에 공통 `Tag` 컴포넌트를 추가했습니다.
- `BottomSheet`와 동일한 구조로 `Tag.tsx`, `Tag.types.ts`, `Tag.stories.tsx`, `index.ts` 파일을 분리해 구성했습니다.
- 선택형/고정형 태그를 `variant`로 분리하고, `selected`, `changeOnClick` props로 상태 확장 가능하도록 구현했습니다.

> 작업한 내용을 체크해주세요.
- [x] `Tag` 컴포넌트 추가
- [x] 타입 정의 및 export 연결
- [x] Storybook 스토리 추가
- [x] 선택형 / 고정형 variant 분리

## 🚀 설계 의도 및 개선점
- 태그의 외형 차이와 상태 변화 여부를 분리해 확장성을 고려했습니다.
- `variant`는 스타일 구분, `selected`와 `changeOnClick`은 상태 제어 역할로 나누어 이후 선택 상태나 비활성 처리에도 대응할 수 있도록 설계했습니다.
- 기존 디자인 시스템 컴포넌트 구조와 맞춰 일관된 방식으로 구성했습니다.

### 📸 스크린샷 (선택)

### 📎 기타 참고사항
- 환경 변수 변경 없음
- 상태 변경은 상위 컴포넌트에서 제어하는 방식으로 사용 가능합니다.

Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 디자인 시스템에 새로운 태그 컴포넌트 추가
  * 4가지 스타일 변형 지원 (기본, 와이드, 정적, 둥근 직사각형)
  * 선택/미선택 상태 관리 기능
  * 클릭 시 자동 상태 전환 옵션
  * Storybook 문서화 및 인터랙티브 예제 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->