### PR TITLE
[Chore/#57] 알림 페이지 오타 수정

### DIFF
--- a/apps/customer/src/app/notice/page.tsx
+++ b/apps/customer/src/app/notice/page.tsx
@@ -4,9 +4,15 @@ import { useState } from "react";
 import { Header } from "@compasser/design-system";
 import NoticeItem from "./_components/NoticeItem";
 import { INITIAL_NOTICES } from "./_constants/mockNotices";
+import { useRouter } from "next/navigation";
 
 export default function Notice() {
   const [notices, setNotices] = useState(INITIAL_NOTICES);
+  const router = useRouter();
+  
+    const handleBack = () => {
+      router.back();
+    };
 
   const handleReadNotice = (id: number) => {
     setNotices((prev) =>
@@ -23,7 +29,11 @@ export default function Notice() {
 
   return (
     <main className="flex min-h-screen flex-col bg-white">
-      <Header variant="center-title-shadow" title="알림" />
+      <Header
+        variant="back-title"
+        title="알림"
+        onBackClick={handleBack}
+      />
 
       <section className="pt-[1.6rem]">
         <div className="border-t border-gray-200">


### PR DESCRIPTION
알림 페이지 오타 수정

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **개선사항**
  * 공지사항 페이지 헤더에 뒤로가기 버튼 기능을 추가했습니다. 사용자는 이제 헤더의 뒤로가기 버튼을 클릭하여 이전 페이지로 편리하게 이동할 수 있으며, 헤더 디자인도 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->