### PR TITLE
[Feat/#51] 사장님 사업자 등록 화면 생성

### DIFF
--- a/apps/owner/src/app/signup/business/page.tsx
+++ b/apps/owner/src/app/signup/business/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Input, Button } from "@compasser/design-system";
+
+export default function BusinessSignupPage() {
+  const router = useRouter();
+
+  const handleNext = () => {
+    router.push("/signup/register");
+  };
+
+  return (
+    <main className="flex h-screen w-full flex-col bg-white">
+      <section className="min-h-0 flex-1 overflow-y-auto px-[1.6rem]">
+        <div className="pt-[36rem]">
+          <div className="w-full">
+            <p className="body2-m pb-[0.8rem] text-default">
+              사업자 등록번호를 입력해주세요!
+            </p>
+            <Input
+              type="text"
+              placeholder="'-' 기호 없이 숫자만 입력해주세요"
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="shrink-0 px-[1.6rem] py-[1.6rem]">
+        <Button
+          type="button"
+          size="lg"
+          kind="default"
+          variant="primary"
+          onClick={handleNext}
+        >
+          다음으로
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/apps/owner/src/app/signup/page.tsx
+++ b/apps/owner/src/app/signup/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { Input, Button } from "@compasser/design-system";
+import { useRouter } from "next/navigation";
 
 export default function SignupPage() {
+  const router = useRouter();
+
   const handleSignup = () => {
     console.log("회원가입");
+    router.push("/signup/business");
   };
 
   return (


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
사업자 등록번호 입력 화면(`/signup/business`)을 추가했습니다.  
회원가입 기본 정보 입력 이후 다음 단계에서 사업자등록번호를 입력할 수 있도록 구성했고, 하단 CTA 버튼을 통해 상점 정보 등록 화면(`/signup/register`)으로 이동되도록 연결했습니다.

> 작업한 내용을 체크해주세요.
- [x] 사업자 등록번호 입력 화면 UI 추가
- [x] 입력 안내 문구 및 placeholder 적용
- [x] 하단 고정 버튼 UI 적용
- [x] `/signup/register` 페이지로 라우팅 연결

## 🚀 설계 의도 및 개선점
실제 서비스에서 사업자등록번호는 하이픈 없이 입력하는 경우가 많아 placeholder에 이를 명시해 입력 오류를 줄이도록 했습니다. 하단 버튼은 기존 회원가입 화면과 동일한 패턴을 유지해 흐름의 일관성을 맞췄고, 이후 상점 등록 단계로 자연스럽게 이어질 수 있도록 라우팅을 연결했습니다.

### 📎 기타 참고사항
- 테스트 방식: 버튼 클릭 시 `/signup/register` 정상 이동 확인
- 환경 변수 변경 여부: 없음

Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 사업자 회원가입 페이지 추가: 사업자 등록번호 입력 필드와 다음 단계 이동 버튼 제공
* 회원가입 플로우 개선: 기본 회원가입 페이지에서 사업자 정보 입력 단계로의 네비게이션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->