### PR TITLE
[Chore/#65] 매장 등록 페이지 컴포넌트 분리

### DIFF
--- a/apps/owner/src/app/signup/register/_components/RegisterSubmitButton.tsx
+++ b/apps/owner/src/app/signup/register/_components/RegisterSubmitButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@compasser/design-system";
+
+interface RegisterSubmitButtonProps {
+  onClick: () => void;
+}
+
+export default function RegisterSubmitButton({
+  onClick,
+}: RegisterSubmitButtonProps) {
+  return (
+    <div className="shrink-0 px-[1.6rem] py-[1.6rem]">
+      <Button
+        type="button"
+        size="lg"
+        kind="default"
+        variant="primary"
+        onClick={onClick}
+      >
+        등록 완료
+      </Button>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/fields/AccountField.tsx
+++ b/apps/owner/src/app/signup/register/_components/fields/AccountField.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Input, Tag } from "@compasser/design-system";
+import type { AccountType } from "../../_types/register";
+
+interface AccountFieldProps {
+  selectedAccountType: AccountType | null;
+  onSelectAccountType: (type: AccountType) => void;
+}
+
+export default function AccountField({
+  selectedAccountType,
+  onSelectAccountType,
+}: AccountFieldProps) {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <p className="body2-m pb-[0.2rem] text-default">계좌번호</p>
+
+      <div className="flex gap-[0.8rem] pb-[0.4rem]">
+        <Tag
+          variant="rounded-rect"
+          selected={selectedAccountType === "bank"}
+          changeOnClick={false}
+          onClick={() => onSelectAccountType("bank")}
+        >
+          은행
+        </Tag>
+
+        <Tag
+          variant="rounded-rect"
+          selected={selectedAccountType === "holder"}
+          changeOnClick={false}
+          onClick={() => onSelectAccountType("holder")}
+        >
+          예금주명
+        </Tag>
+      </div>
+
+      <Input type="text" placeholder="계좌번호를 입력해주세요" />
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/fields/EmailField.tsx
+++ b/apps/owner/src/app/signup/register/_components/fields/EmailField.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Input } from "@compasser/design-system";
+
+export default function EmailField() {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <p className="body2-m pb-[0.2rem] text-default">이메일</p>
+      <Input type="email" placeholder="이메일을 입력해주세요" />
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/fields/StoreAddressField.tsx
+++ b/apps/owner/src/app/signup/register/_components/fields/StoreAddressField.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button, Input } from "@compasser/design-system";
+
+interface StoreAddressFieldProps {
+  onSearchAddress: () => void;
+}
+
+export default function StoreAddressField({
+  onSearchAddress,
+}: StoreAddressFieldProps) {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <p className="body2-m pb-[0.2rem] text-default">상점 주소</p>
+
+      <div className="flex items-end gap-[1rem]">
+        <div className="min-w-0 flex-1">
+          <Input type="text" placeholder="상점 주소를 입력해주세요" />
+        </div>
+
+        <Button
+          type="button"
+          kind="default"
+          size="lg"
+          variant="primary"
+          fullWidth={false}
+          onClick={onSearchAddress}
+          className="body1-m shrink-0 px-[2.1rem] py-[1.15rem] text-inverse"
+        >
+          검색
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/fields/StoreNameField.tsx
+++ b/apps/owner/src/app/signup/register/_components/fields/StoreNameField.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Input } from "@compasser/design-system";
+
+export default function StoreNameField() {
+  return (
+    <div className="w-full">
+      <p className="body2-m py-[0.2rem] text-default">상점 이름</p>
+      <Input type="text" placeholder="상점 이름을 입력해주세요" />
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/sections/BusinessHoursSection.tsx
+++ b/apps/owner/src/app/signup/register/_components/sections/BusinessHoursSection.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button, Icon } from "@compasser/design-system";
+
+type BusinessHoursRow = {
+  dayLabel: string;
+  time: string;
+};
+
+interface BusinessHoursSectionProps {
+  businessHoursRows: BusinessHoursRow[];
+  onOpenBusinessHoursModal: () => void;
+}
+
+export default function BusinessHoursSection({
+  businessHoursRows,
+  onOpenBusinessHoursModal,
+}: BusinessHoursSectionProps) {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <div className="flex items-center justify-between">
+        <p className="body2-m pb-[0.2rem] text-default">영업시간 등록</p>
+
+        <Button
+          type="button"
+          kind="register"
+          variant="outline-primary"
+          fullWidth={false}
+          onClick={onOpenBusinessHoursModal}
+          className="body1-m border border-primary-variant text-primary-variant"
+        >
+          등록하기
+        </Button>
+      </div>
+
+      <div className="flex items-start pt-[0.4rem]">
+        <div className="shrink-0 pt-[0.2rem]">
+          <Icon name="Clock" width={20} height={20} />
+        </div>
+
+        <div className="ml-[0.4rem] flex flex-col gap-[0.4rem]">
+          {businessHoursRows.map((row) => (
+            <div key={row.dayLabel} className="flex items-center gap-[0.4rem]">
+              <span className="body2-r text-default">{row.dayLabel}</span>
+              <span className="body2-r text-default">{row.time}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/sections/PhotoUploadSection.tsx
+++ b/apps/owner/src/app/signup/register/_components/sections/PhotoUploadSection.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Icon } from "@compasser/design-system";
+
+export default function PhotoUploadSection() {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <p className="body2-m text-default">사진 첨부</p>
+      <p className="caption1-r pb-[0.2rem] text-gray-500">
+        상점의 대표 이미지를 추가해주세요!
+      </p>
+
+      <button
+        type="button"
+        className="flex h-[18rem] w-full items-center justify-center rounded-[10px] bg-background"
+      >
+        <Icon name="Camera" width={24} height={24} />
+      </button>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/sections/RandomBoxSection.tsx
+++ b/apps/owner/src/app/signup/register/_components/sections/RandomBoxSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Button, Card } from "@compasser/design-system";
+import type { RandomBoxItem } from "../../_types/register";
+
+interface RandomBoxSectionProps {
+  randomBoxes: RandomBoxItem[];
+  selectedRandomBoxIds: number[];
+  onToggleRandomBoxSelection: (id: number) => void;
+  onDeleteRandomBoxes: () => void;
+  onAddRandomBox: () => void;
+}
+
+export default function RandomBoxSection({
+  randomBoxes,
+  selectedRandomBoxIds,
+  onToggleRandomBoxSelection,
+  onDeleteRandomBoxes,
+  onAddRandomBox,
+}: RandomBoxSectionProps) {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <div className="flex items-center justify-between">
+        <p className="body2-m pb-[0.2rem] text-default">랜덤박스 등록</p>
+
+        <div className="flex items-center">
+          <Button
+            type="button"
+            kind="register"
+            variant="outline-gray"
+            fullWidth={false}
+            onClick={onDeleteRandomBoxes}
+            className="body1-m border border-gray-600 text-gray-600"
+          >
+            삭제하기
+          </Button>
+
+          <div className="w-[1.2rem]" />
+
+          <Button
+            type="button"
+            kind="register"
+            variant="outline-primary"
+            fullWidth={false}
+            onClick={onAddRandomBox}
+            className="body1-m border border-primary-variant text-primary-variant"
+          >
+            추가하기
+          </Button>
+        </div>
+      </div>
+
+      <div className="pt-[0.4rem]">
+        <Card variant="gray-300-bordered" className="overflow-hidden p-0">
+          <div className="grid grid-cols-4 border-b border-gray-300 px-[1rem] py-[1rem]">
+            <div className="body2-m text-center text-gray-600">이름</div>
+            <div className="body2-m text-center text-gray-600">수량</div>
+            <div className="body2-m text-center text-gray-600">가격</div>
+            <div className="body2-m text-center text-gray-600">제한</div>
+          </div>
+
+          <div
+            className={
+              randomBoxes.length >= 3 ? "max-h-[13.2rem] overflow-y-auto" : ""
+            }
+          >
+            {randomBoxes.map((item) => {
+              const isSelected = selectedRandomBoxIds.includes(item.id);
+
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => onToggleRandomBoxSelection(item.id)}
+                  className={`grid w-full grid-cols-4 px-[1rem] py-[1rem] text-center ${
+                    isSelected ? "bg-background" : "bg-white"
+                  }`}
+                >
+                  <div className="body2-r text-default">{item.name}</div>
+                  <div className="body2-r text-default">{item.quantity}</div>
+                  <div className="body2-r text-default">
+                    {item.price.toLocaleString()}
+                  </div>
+                  <div className="body2-r text-default">{item.limit}</div>
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/sections/TagSection.tsx
+++ b/apps/owner/src/app/signup/register/_components/sections/TagSection.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Tag } from "@compasser/design-system";
+
+interface TagSectionProps {
+  tagOptions: string[];
+  selectedTags: string[];
+  onToggleTag: (tag: string) => void;
+}
+
+export default function TagSection({
+  tagOptions,
+  selectedTags,
+  onToggleTag,
+}: TagSectionProps) {
+  return (
+    <div className="mt-[3.6rem] w-full">
+      <p className="body2-m text-default">태그 등록</p>
+      <p className="caption1-r text-gray-500">가게의 태그를 선택해주세요!</p>
+
+      <div className="flex flex-wrap gap-[0.8rem] pt-[1.4rem]">
+        {tagOptions.map((tag) => (
+          <Tag
+            key={tag}
+            variant="pill-wide"
+            selected={selectedTags.includes(tag)}
+            onClick={() => onToggleTag(tag)}
+          >
+            {tag}
+          </Tag>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_constants/register.ts
+++ b/apps/owner/src/app/signup/register/_constants/register.ts
@@ -1,0 +1,39 @@
+import type { BusinessHours, RandomBoxItem } from "../_types/register";
+
+export const businessHoursData: BusinessHours = {
+  fri: "09:00-21:00",
+  mon: "09:00-21:00",
+  sat: "10:00-18:00",
+  sun: "closed",
+  thu: "09:00-21:00",
+  tue: "09:00-21:00",
+  wed: "09:00-21:00",
+};
+
+export const dayLabelMap: Record<keyof BusinessHours, string> = {
+  mon: "월",
+  tue: "화",
+  wed: "수",
+  thu: "목",
+  fri: "금",
+  sat: "토",
+  sun: "일",
+};
+
+export const orderedDays: (keyof BusinessHours)[] = [
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+  "sun",
+];
+
+export const initialRandomBoxes: RandomBoxItem[] = [
+  { id: 1, name: "Level.1", quantity: 5, price: 6000, limit: 1 },
+  { id: 2, name: "Level.2", quantity: 3, price: 10000, limit: 1 },
+  { id: 3, name: "Level.3", quantity: 1, price: 15000, limit: 1 },
+];
+
+export const tagOptions = ["카페", "베이커리", "식당"];

--- a/apps/owner/src/app/signup/register/_types/register.ts
+++ b/apps/owner/src/app/signup/register/_types/register.ts
@@ -1,0 +1,19 @@
+export type BusinessHours = {
+  mon: string;
+  tue: string;
+  wed: string;
+  thu: string;
+  fri: string;
+  sat: string;
+  sun: string;
+};
+
+export type RandomBoxItem = {
+  id: number;
+  name: string;
+  quantity: number;
+  price: number;
+  limit: number;
+};
+
+export type AccountType = "bank" | "holder";

--- a/apps/owner/src/app/signup/register/page.tsx
+++ b/apps/owner/src/app/signup/register/page.tsx
@@ -1,83 +1,27 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import {
-  Input,
-  Button,
-  Tag,
-  Card,
-  Icon,
-} from "@compasser/design-system";
 import { useRouter } from "next/navigation";
-
-type BusinessHours = {
-  mon: string;
-  tue: string;
-  wed: string;
-  thu: string;
-  fri: string;
-  sat: string;
-  sun: string;
-};
-
-type RandomBoxItem = {
-  id: number;
-  name: string;
-  quantity: number;
-  price: number;
-  limit: number;
-};
-
-const businessHoursData: BusinessHours = {
-  fri: "09:00-21:00",
-  mon: "09:00-21:00",
-  sat: "10:00-18:00",
-  sun: "closed",
-  thu: "09:00-21:00",
-  tue: "09:00-21:00",
-  wed: "09:00-21:00",
-};
-
-const dayLabelMap: Record<keyof BusinessHours, string> = {
-  mon: "월",
-  tue: "화",
-  wed: "수",
-  thu: "목",
-  fri: "금",
-  sat: "토",
-  sun: "일",
-};
-
-const orderedDays: (keyof BusinessHours)[] = [
-  "mon",
-  "tue",
-  "wed",
-  "thu",
-  "fri",
-  "sat",
-  "sun",
-];
-
-const initialRandomBoxes: RandomBoxItem[] = [
-  { id: 1, name: "Level.1", quantity: 5, price: 6000, limit: 1 },
-  { id: 2, name: "Level.2", quantity: 3, price: 10000, limit: 1 },
-  { id: 3, name: "Level.3", quantity: 1, price: 15000, limit: 1 },
-];
-
-const tagOptions = ["카페", "베이커리", "식당"];
+import StoreNameField from "./_components/fields/StoreNameField";
+import EmailField from "./_components/fields/EmailField";
+import StoreAddressField from "./_components/fields/StoreAddressField";
+import AccountField from "./_components/fields/AccountField";
+import BusinessHoursSection from "./_components/sections/BusinessHoursSection";
+import RandomBoxSection from "./_components/sections/RandomBoxSection";
+import PhotoUploadSection from "./_components/sections/PhotoUploadSection";
+import TagSection from "./_components/sections/TagSection";
+import RegisterSubmitButton from "./_components/RegisterSubmitButton";
+import { businessHoursData, dayLabelMap, orderedDays, initialRandomBoxes, tagOptions } from "./_constants/register";
+import type { AccountType, RandomBoxItem } from "./_types/register";
 
 export default function StoreRegisterPage() {
   const router = useRouter();
-  
-  const [selectedAccountType, setSelectedAccountType] = useState<
-    "bank" | "holder" | null
-  >(null);
 
+  const [selectedAccountType, setSelectedAccountType] =
+    useState<AccountType | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-
   const [randomBoxes, setRandomBoxes] =
     useState<RandomBoxItem[]>(initialRandomBoxes);
-
   const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>(
     []
   );
@@ -85,10 +29,7 @@ export default function StoreRegisterPage() {
   const businessHoursRows = useMemo(() => {
     return orderedDays.map((day) => {
       const value = businessHoursData[day];
-      const formatted =
-        value === "closed"
-          ? "휴무"
-          : value.replace("-", " ~ ");
+      const formatted = value === "closed" ? "휴무" : value.replace("-", " ~ ");
 
       return {
         dayLabel: dayLabelMap[day],
@@ -139,7 +80,6 @@ export default function StoreRegisterPage() {
   };
 
   const handleOpenBusinessHoursModal = () => {
-    // 나중에 모달 연결
     console.log("영업시간 등록 모달 오픈");
   };
 
@@ -155,214 +95,38 @@ export default function StoreRegisterPage() {
     <main className="flex w-full flex-col bg-white">
       <section className="min-h-0 flex-1 overflow-y-auto px-[1.6rem]">
         <div className="pb-[3.6rem]">
-          <div className="w-full">
-            <p className="body2-m py-[0.2rem] text-default">상점 이름</p>
-            <Input type="text" placeholder="상점 이름을 입력해주세요" />
-          </div>
+          <StoreNameField />
+          <EmailField />
+          <StoreAddressField onSearchAddress={handleSearchAddress} />
+          <AccountField
+            selectedAccountType={selectedAccountType}
+            onSelectAccountType={setSelectedAccountType}
+          />
 
-          <div className="mt-[3.6rem] w-full">
-            <p className="body2-m pb-[0.2rem] text-default">이메일</p>
-            <Input type="email" placeholder="이메일을 입력해주세요" />
-          </div>
+          <BusinessHoursSection
+            businessHoursRows={businessHoursRows}
+            onOpenBusinessHoursModal={handleOpenBusinessHoursModal}
+          />
 
-          <div className="mt-[3.6rem] w-full">
-            <p className="body2-m pb-[0.2rem] text-default">상점 주소</p>
+          <RandomBoxSection
+            randomBoxes={randomBoxes}
+            selectedRandomBoxIds={selectedRandomBoxIds}
+            onToggleRandomBoxSelection={toggleRandomBoxSelection}
+            onDeleteRandomBoxes={handleDeleteRandomBoxes}
+            onAddRandomBox={handleAddRandomBox}
+          />
 
-            <div className="flex items-end gap-[1rem]">
-              <div className="min-w-0 flex-1">
-                <Input type="text" placeholder="상점 주소를 입력해주세요" />
-              </div>
+          <PhotoUploadSection />
 
-              <Button
-                type="button"
-                kind="default"
-                size="lg"
-                variant="primary"
-                fullWidth={false}
-                onClick={handleSearchAddress}
-                className="shrink-0 px-[2.1rem] py-[1.15rem] body1-m text-inverse"
-              >
-                검색
-              </Button>
-            </div>
-          </div>
-
-          <div className="mt-[3.6rem] w-full">
-            <p className="body2-m pb-[0.2rem] text-default">계좌번호</p>
-
-            <div className="flex gap-[0.8rem] pb-[0.4rem]">
-              <Tag
-                variant="rounded-rect"
-                selected={selectedAccountType === "bank"}
-                changeOnClick={false}
-                onClick={() => setSelectedAccountType("bank")}
-              >
-                은행
-              </Tag>
-
-              <Tag
-                variant="rounded-rect"
-                selected={selectedAccountType === "holder"}
-                changeOnClick={false}
-                onClick={() => setSelectedAccountType("holder")}
-              >
-                예금주명
-              </Tag>
-            </div>
-
-            <Input type="text" placeholder="계좌번호를 입력해주세요" />
-          </div>
-
-          <div className="mt-[3.6rem] w-full">
-            <div className="flex items-center justify-between">
-              <p className="body2-m pb-[0.2rem] text-default">영업시간 등록</p>
-
-              <Button
-                type="button"
-                kind="register"
-                variant="outline-primary"
-                fullWidth={false}
-                onClick={handleOpenBusinessHoursModal}
-                className="body1-m border border-primary-variant text-primary-variant"
-              >
-                등록하기
-              </Button>
-            </div>
-
-            <div className="pt-[0.4rem] flex items-start">
-              <div className="shrink-0 pt-[0.2rem]">
-                <Icon name="Clock" width={20} height={20} />
-              </div>
-
-              <div className="ml-[0.4rem] flex flex-col gap-[0.4rem]">
-                {businessHoursRows.map((row) => (
-                  <div key={row.dayLabel} className="flex items-center gap-[0.4rem]">
-                    <span className="body2-r text-default">{row.dayLabel}</span>
-                    <span className="body2-r text-default">{row.time}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-[3.6rem] w-full">
-            <div className="flex items-center justify-between">
-              <p className="body2-m pb-[0.2rem] text-default">랜덤박스 등록</p>
-
-              <div className="flex items-center">
-                <Button
-                  type="button"
-                  kind="register"
-                  variant="outline-gray"
-                  fullWidth={false}
-                  onClick={handleDeleteRandomBoxes}
-                  className="body1-m border border-gray-600 text-gray-600"
-                >
-                  삭제하기
-                </Button>
-
-                <div className="w-[1.2rem]" />
-
-                <Button
-                  type="button"
-                  kind="register"
-                  variant="outline-primary"
-                  fullWidth={false}
-                  onClick={handleAddRandomBox}
-                  className="body1-m border border-primary-variant text-primary-variant"
-                >
-                  추가하기
-                </Button>
-              </div>
-            </div>
-
-            <div className="pt-[0.4rem]">
-              <Card variant="gray-300-bordered" className="p-0 overflow-hidden">
-                <div className="grid grid-cols-4 border-b border-gray-300 px-[1rem] py-[1rem]">
-                  <div className="text-center body2-m text-gray-600">이름</div>
-                  <div className="text-center body2-m text-gray-600">수량</div>
-                  <div className="text-center body2-m text-gray-600">가격</div>
-                  <div className="text-center body2-m text-gray-600">제한</div>
-                </div>
-
-                <div
-                  className={`${
-                    randomBoxes.length >= 3 ? "max-h-[13.2rem] overflow-y-auto" : ""
-                  }`}
-                >
-                  {randomBoxes.map((item) => {
-                    const isSelected = selectedRandomBoxIds.includes(item.id);
-
-                    return (
-                      <button
-                        key={item.id}
-                        type="button"
-                        onClick={() => toggleRandomBoxSelection(item.id)}
-                        className={`grid w-full grid-cols-4 px-[1rem] py-[1rem] text-center ${
-                          isSelected ? "bg-background" : "bg-white"
-                        }`}
-                      >
-                        <div className="body2-r text-default">{item.name}</div>
-                        <div className="body2-r text-default">{item.quantity}</div>
-                        <div className="body2-r text-default">
-                          {item.price.toLocaleString()}
-                        </div>
-                        <div className="body2-r text-default">{item.limit}</div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </Card>
-            </div>
-          </div>
-
-          <div className="mt-[3.6rem] w-full">
-            <p className="body2-m text-default">사진 첨부</p>
-            <p className="caption1-r pb-[0.2rem] text-gray-500">
-              상점의 대표 이미지를 추가해주세요!
-            </p>
-
-            <button
-              type="button"
-              className="flex h-[18rem] w-full items-center justify-center rounded-[10px] bg-background"
-            >
-              <Icon name="Camera" width={24} height={24} />
-            </button>
-          </div>
-
-          <div className="mt-[3.6rem] w-full">
-            <p className="body2-m text-default">태그 등록</p>
-            <p className="caption1-r text-gray-500">
-              가게의 태그를 선택해주세요!
-            </p>
-
-            <div className="pt-[1.4rem] flex flex-wrap gap-[0.8rem]">
-              {tagOptions.map((tag) => (
-                <Tag
-                  key={tag}
-                  variant="pill-wide"
-                  selected={selectedTags.includes(tag)}
-                  onClick={() => toggleTag(tag)}
-                >
-                  {tag}
-                </Tag>
-              ))}
-            </div>
-          </div>
+          <TagSection
+            tagOptions={tagOptions}
+            selectedTags={selectedTags}
+            onToggleTag={toggleTag}
+          />
         </div>
       </section>
 
-      <div className="shrink-0 px-[1.6rem] py-[1.6rem]">
-        <Button
-          type="button"
-          size="lg"
-          kind="default"
-          variant="primary"
-          onClick={handleCompleteRegister}
-        >
-          등록 완료
-        </Button>
-      </div>
+      <RegisterSubmitButton onClick={handleCompleteRegister} />
     </main>
   );
 }


### PR DESCRIPTION
## 가게 등록 페이지 컴포넌트 분리

register
├─ _components
│  ├─ fields
│  │  ├─ StoreNameField.tsx
│  │  ├─ EmailField.tsx
│  │  ├─ StoreAddressField.tsx
│  │  └─ AccountField.tsx
│  ├─ sections
│  │  ├─ BusinessHoursSection.tsx
│  │  ├─ RandomBoxSection.tsx
│  │  ├─ PhotoUploadSection.tsx
│  │  └─ TagSection.tsx
│  └─ RegisterSubmitButton.tsx
├─ _constants
├─ _types
└─ page.tsx

Fixes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상점 등록 폼 추가: 상점명, 이메일, 주소, 계좌 정보, 영업시간, 랜덤박스, 사진, 태그 등록 기능 포함
  * 상점 등록 완료 버튼 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->