### PR TITLE
[Feat/#68] 매장 등록 페이지 모달창 생성

### DIFF
--- a/apps/owner/src/app/signup/register/_components/modals/BusinessHoursModal.tsx
+++ b/apps/owner/src/app/signup/register/_components/modals/BusinessHoursModal.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button, Modal } from "@compasser/design-system";
+
+import { cn } from "@compasser/design-system";
+import {
+  dayOptions,
+  initialBusinessHourFormValue,
+} from "../../_constants/register";
+import type {
+  BusinessHourFormValue,
+  BreakTimeOption,
+  DayKey,
+} from "../../_types/register";
+import TimeRangeField from "./TimeRangeField";
+
+interface BusinessHoursModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit?: (data: Record<DayKey, BusinessHourFormValue>) => void;
+}
+
+const getEmptyBusinessHoursForm = (): Record<DayKey, BusinessHourFormValue> => ({
+  mon: { ...initialBusinessHourFormValue },
+  tue: { ...initialBusinessHourFormValue },
+  wed: { ...initialBusinessHourFormValue },
+  thu: { ...initialBusinessHourFormValue },
+  fri: { ...initialBusinessHourFormValue },
+  sat: { ...initialBusinessHourFormValue },
+  sun: { ...initialBusinessHourFormValue },
+});
+
+export default function BusinessHoursModal({
+  open,
+  onClose,
+  onSubmit,
+}: BusinessHoursModalProps) {
+  const [selectedDay, setSelectedDay] = useState<DayKey>("mon");
+  const [businessHoursForm, setBusinessHoursForm] = useState<
+    Record<DayKey, BusinessHourFormValue>
+  >(getEmptyBusinessHoursForm());
+
+  const selectedDayValue = businessHoursForm[selectedDay];
+
+  const updateSelectedDayField = (
+    key: keyof BusinessHourFormValue,
+    value: string | BreakTimeOption | null
+  ) => {
+    setBusinessHoursForm((prev) => ({
+      ...prev,
+      [selectedDay]: {
+        ...prev[selectedDay],
+        [key]: value,
+      },
+    }));
+  };
+
+  const handleChangeBreakTimeOption = (value: BreakTimeOption) => {
+    setBusinessHoursForm((prev) => {
+      const current = prev[selectedDay];
+
+      return {
+        ...prev,
+        [selectedDay]: {
+          ...current,
+          hasBreakTime: value,
+          ...(value === "no"
+            ? {
+                breakStartTime: "",
+                breakEndTime: "",
+              }
+            : {}),
+        },
+      };
+    });
+  };
+
+  const isDayCompleted = (value: BusinessHourFormValue) => {
+    const hasOpenClose = value.openTime.trim() !== "" && value.closeTime.trim() !== "";
+
+    if (!hasOpenClose) {
+      return false;
+    }
+
+    if (value.hasBreakTime === "no") {
+      return true;
+    }
+
+    if (value.hasBreakTime === "yes") {
+      return (
+        value.breakStartTime.trim() !== "" && value.breakEndTime.trim() !== ""
+      );
+    }
+
+    return false;
+  };
+
+  const completedDays = useMemo(() => {
+    return dayOptions.reduce<Record<DayKey, boolean>>((acc, day) => {
+      acc[day.key] = isDayCompleted(businessHoursForm[day.key]);
+      return acc;
+    }, {} as Record<DayKey, boolean>);
+  }, [businessHoursForm]);
+
+  const isRegisterButtonEnabled = useMemo(() => {
+    return dayOptions.some((day) => completedDays[day.key]);
+  }, [completedDays]);
+
+  const handleSubmit = () => {
+    if (!isRegisterButtonEnabled) {
+      return;
+    }
+
+    onSubmit?.(businessHoursForm);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="default"
+      closeOnOverlayClick
+      className="w-[91%] border border-primary px-[1rem] pt-[2.4rem] pb-[1rem]"
+      bodyClassName="mt-0"
+    >
+      <div>
+        <div className="flex flex-wrap gap-x-[0.95rem] gap-y-[0.8rem]">
+          {dayOptions.map((day) => {
+            const isSelected = selectedDay === day.key;
+            const isCompleted = completedDays[day.key];
+
+            return (
+              <button
+                key={day.key}
+                type="button"
+                onClick={() => setSelectedDay(day.key)}
+                className={cn(
+                  "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                  isSelected
+                    ? "border-primary-variant bg-primary-variant"
+                    : "border-gray-300 bg-white"
+                )}
+              >
+                <span
+                  className={cn(
+                    "body1-r",
+                    isSelected ? "text-gray-100" : "text-gray-600"
+                  )}
+                >
+                  {day.label}
+                </span>
+
+                {isCompleted && !isSelected && (
+                  <span className="sr-only">입력 완료</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="pt-[2.8rem]">
+          <div className="flex items-center">
+            <p className="body1-r shrink-0 text-gray-700">영업시간</p>
+
+            <TimeRangeField
+              startTime={selectedDayValue.openTime}
+              endTime={selectedDayValue.closeTime}
+              onChangeStartTime={(value) => updateSelectedDayField("openTime", value)}
+              onChangeEndTime={(value) => updateSelectedDayField("closeTime", value)}
+              className="ml-[5.2rem]"
+            />
+          </div>
+
+          <div className="pt-[1.6rem]">
+            <div className="flex items-center">
+              <p className="body1-r shrink-0 text-gray-700">브레이크타임</p>
+
+              <div className="ml-[2.5rem] flex items-center gap-[0.4rem]">
+                <button
+                  type="button"
+                  onClick={() => handleChangeBreakTimeOption("yes")}
+                  className={cn(
+                    "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                    selectedDayValue.hasBreakTime === "yes"
+                      ? "border-primary-variant bg-primary-variant"
+                      : "border-gray-300 bg-white"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "body1-r",
+                      selectedDayValue.hasBreakTime === "yes"
+                        ? "text-gray-100"
+                        : "text-gray-600"
+                    )}
+                  >
+                    유
+                  </span>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => handleChangeBreakTimeOption("no")}
+                  className={cn(
+                    "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                    selectedDayValue.hasBreakTime === "no"
+                      ? "border-primary-variant bg-primary-variant"
+                      : "border-gray-300 bg-white"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "body1-r",
+                      selectedDayValue.hasBreakTime === "no"
+                        ? "text-gray-100"
+                        : "text-gray-600"
+                    )}
+                  >
+                    무
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            {selectedDayValue.hasBreakTime === "yes" && (
+              <div className="pl-[10.6rem] pt-[0.8rem]">
+                <TimeRangeField
+                  startTime={selectedDayValue.breakStartTime}
+                  endTime={selectedDayValue.breakEndTime}
+                  onChangeStartTime={(value) =>
+                    updateSelectedDayField("breakStartTime", value)
+                  }
+                  onChangeEndTime={(value) =>
+                    updateSelectedDayField("breakEndTime", value)
+                  }
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="pt-[1.6rem]">
+            <Button
+              type="button"
+              variant="primary"
+              size="lg"
+              kind="default"
+              disabled={!isRegisterButtonEnabled}
+              onClick={handleSubmit}
+            >
+              등록하기
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/modals/CountStepper.tsx
+++ b/apps/owner/src/app/signup/register/_components/modals/CountStepper.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { cn } from "@compasser/design-system";
+
+interface CountStepperProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  className?: string;
+}
+
+export default function CountStepper({
+  value,
+  onChange,
+  min = 0,
+  className,
+}: CountStepperProps) {
+  const isMinusDisabled = value <= min;
+
+  const handleDecrease = () => {
+    if (isMinusDisabled) return;
+    onChange(value - 1);
+  };
+
+  const handleIncrease = () => {
+    onChange(value + 1);
+  };
+
+  return (
+    <div className={cn("inline-flex items-stretch", className)}>
+      <button
+        type="button"
+        onClick={handleDecrease}
+        disabled={isMinusDisabled}
+        className={cn(
+          "flex items-center justify-center rounded-l-[4px] border border-r-0 border-gray-300 px-[1.15rem] py-[1.15rem]",
+          isMinusDisabled ? "text-gray-300" : "text-gray-600"
+        )}
+      >
+        <span className="body1-r">−</span>
+      </button>
+
+      <div className="flex items-center justify-center border border-gray-300 px-[1.6rem] py-[0.6rem]">
+        <span className="body1-r text-gray-600">{value}</span>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleIncrease}
+        className="flex items-center justify-center rounded-r-[4px] border border-l-0 border-gray-300 px-[1.15rem] py-[1.15rem] text-gray-600"
+      >
+        <span className="body1-r">+</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/modals/RandomBoxModal.tsx
+++ b/apps/owner/src/app/signup/register/_components/modals/RandomBoxModal.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button, Input, Modal, cn } from "@compasser/design-system";
+import TimeRangeField from "./TimeRangeField";
+import CountStepper from "./CountStepper";
+import type { RandomBoxFormValue } from "../../_types/register";
+
+interface RandomBoxModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit?: (data: RandomBoxFormValue) => void;
+}
+
+const initialFormValue: RandomBoxFormValue = {
+  name: "",
+  quantity: 0,
+  limit: 0,
+  pickupStartTime: "00:00",
+  pickupEndTime: "00:00",
+  description: "",
+};
+
+export default function RandomBoxModal({
+  open,
+  onClose,
+  onSubmit,
+}: RandomBoxModalProps) {
+  const [form, setForm] = useState<RandomBoxFormValue>(initialFormValue);
+
+  useEffect(() => {
+    if (!open) {
+      setForm(initialFormValue);
+    }
+  }, [open]);
+
+  const updateField = <K extends keyof RandomBoxFormValue>(
+    key: K,
+    value: RandomBoxFormValue[K]
+  ) => {
+    setForm((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  const handleSubmit = () => {
+    onSubmit?.(form);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="default"
+      closeOnOverlayClick
+      className="w-[91%] border border-primary px-[1rem] py-[2rem]"
+      bodyClassName="mt-0"
+    >
+      <div className="flex flex-col gap-[1.6rem]">
+        <div className="flex w-full items-center justify-between gap-[1.6rem]">
+          <p className="body1-r shrink-0 text-gray-700">랜덤박스 이름</p>
+
+          <Input
+            value={form.name}
+            onChange={(event) => updateField("name", event.target.value)}
+            className="w-[17rem]"
+            containerClassName="border-gray-300"
+            inputClassName="text-gray-600"
+          />
+        </div>
+
+        <div className="flex w-full items-center gap-[1.6rem]">
+          <p className="body1-r shrink-0 text-gray-700">총 수량</p>
+
+          <div className="ml-auto flex w-[17rem] justify-start">
+            <CountStepper
+              value={form.quantity}
+              onChange={(value) => updateField("quantity", value)}
+              min={0}
+            />
+          </div>
+        </div>
+
+        <div className="flex w-full items-center gap-[1.6rem]">
+          <p className="body1-r shrink-0 text-gray-700">구매 제한 개수</p>
+
+          <div className="ml-auto flex w-[17rem] justify-start">
+            <CountStepper
+              value={form.limit}
+              onChange={(value) => updateField("limit", value)}
+              min={0}
+            />
+          </div>
+        </div>
+
+        <div className="flex w-full items-center gap-[1.6rem]">
+          <p className="body1-r shrink-0 text-gray-700">픽업 시간</p>
+
+          <div className="ml-auto flex w-[17rem] justify-start">
+            <TimeRangeField
+              startTime={form.pickupStartTime}
+              endTime={form.pickupEndTime}
+              onChangeStartTime={(value) => updateField("pickupStartTime", value)}
+              onChangeEndTime={(value) => updateField("pickupEndTime", value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <p className="body1-r text-gray-700">랜덤박스 설명란</p>
+
+          <textarea
+            value={form.description}
+            onChange={(event) => updateField("description", event.target.value)}
+            className={cn(
+              "mt-[0.4rem] h-[15rem] w-full resize-none rounded-[8px] border border-gray-300 px-[1rem] py-[1rem]",
+              "body1-r text-gray-700 outline-none placeholder:text-gray-500"
+            )}
+          />
+        </div>
+
+        <div className="pt-[1.6rem]">
+          <Button
+            type="button"
+            variant="primary"
+            size="lg"
+            kind="default"
+            onClick={handleSubmit}
+          >
+            추가하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/modals/TimeRangeField.tsx
+++ b/apps/owner/src/app/signup/register/_components/modals/TimeRangeField.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useRef } from "react";
+import { cn } from "@compasser/design-system";
+
+interface TimeRangeFieldProps {
+  startTime: string;
+  endTime: string;
+  onChangeStartTime: (value: string) => void;
+  onChangeEndTime: (value: string) => void;
+  className?: string;
+}
+
+const formatTime = (value: string) => {
+  return value && value.trim() !== "" ? value : "00:00";
+};
+
+export default function TimeRangeField({
+  startTime,
+  endTime,
+  onChangeStartTime,
+  onChangeEndTime,
+  className,
+}: TimeRangeFieldProps) {
+  const startInputRef = useRef<HTMLInputElement | null>(null);
+  const endInputRef = useRef<HTMLInputElement | null>(null);
+
+  const openStartPicker = () => {
+    if (!startInputRef.current) return;
+
+    if ("showPicker" in HTMLInputElement.prototype) {
+      startInputRef.current.showPicker();
+      return;
+    }
+
+    startInputRef.current.focus();
+    startInputRef.current.click();
+  };
+
+  const openEndPicker = () => {
+    if (!endInputRef.current) return;
+
+    if ("showPicker" in HTMLInputElement.prototype) {
+      endInputRef.current.showPicker();
+      return;
+    }
+
+    endInputRef.current.focus();
+    endInputRef.current.click();
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative inline-flex items-center rounded-[8px] border border-gray-300 px-[1rem] py-[1rem]",
+        className
+      )}
+    >
+      <button
+        type="button"
+        onClick={openStartPicker}
+        className="body1-r shrink-0 text-gray-600"
+      >
+        {formatTime(startTime)}
+      </button>
+
+      <span className="body1-r px-[0.8rem] text-gray-600">~</span>
+
+      <button
+        type="button"
+        onClick={openEndPicker}
+        className="body1-r shrink-0 text-gray-600"
+      >
+        {formatTime(endTime)}
+      </button>
+
+      <input
+        ref={startInputRef}
+        type="time"
+        value={startTime}
+        onChange={(event) => onChangeStartTime(event.target.value)}
+        className="absolute h-0 w-0 opacity-0"
+        tabIndex={-1}
+        aria-hidden="true"
+      />
+
+      <input
+        ref={endInputRef}
+        type="time"
+        value={endTime}
+        onChange={(event) => onChangeEndTime(event.target.value)}
+        className="absolute h-0 w-0 opacity-0"
+        tabIndex={-1}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/sections/PhotoUploadSection.tsx
+++ b/apps/owner/src/app/signup/register/_components/sections/PhotoUploadSection.tsx
@@ -1,8 +1,33 @@
 "use client";
 
+import { ChangeEvent, useRef } from "react";
+import Image from "next/image";
 import { Icon } from "@compasser/design-system";
 
-export default function PhotoUploadSection() {
+interface PhotoUploadSectionProps {
+  previewUrl?: string;
+  onChangePhoto: (file: File) => void;
+}
+
+export default function PhotoUploadSection({
+  previewUrl,
+  onChangePhoto,
+}: PhotoUploadSectionProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleOpenFilePicker = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleChangeFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    onChangePhoto(file);
+
+    event.target.value = "";
+  };
+
   return (
     <div className="mt-[3.6rem] w-full">
       <p className="body2-m text-default">사진 첨부</p>
@@ -12,10 +37,28 @@ export default function PhotoUploadSection() {
 
       <button
         type="button"
-        className="flex h-[18rem] w-full items-center justify-center rounded-[10px] bg-background"
+        onClick={handleOpenFilePicker}
+        className="relative flex h-[18rem] w-full items-center justify-center overflow-hidden rounded-[10px] bg-background"
       >
-        <Icon name="Camera" width={24} height={24} />
+        {previewUrl ? (
+          <Image
+            src={previewUrl}
+            alt="업로드한 대표 이미지 미리보기"
+            fill
+            className="object-cover"
+          />
+        ) : (
+          <Icon name="Camera" width={24} height={24} />
+        )}
       </button>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleChangeFile}
+        className="hidden"
+      />
     </div>
   );
 }

--- a/apps/owner/src/app/signup/register/_constants/register.ts
+++ b/apps/owner/src/app/signup/register/_constants/register.ts
@@ -1,4 +1,9 @@
-import type { BusinessHours, RandomBoxItem } from "../_types/register";
+import type {
+  BusinessHours,
+  RandomBoxItem,
+  DayKey,
+  BusinessHourFormValue,
+} from "../_types/register";
 
 export const businessHoursData: BusinessHours = {
   fri: "09:00-21:00",
@@ -37,3 +42,21 @@ export const initialRandomBoxes: RandomBoxItem[] = [
 ];
 
 export const tagOptions = ["카페", "베이커리", "식당"];
+
+export const dayOptions: { key: DayKey; label: string }[] = [
+  { key: "mon", label: "월" },
+  { key: "tue", label: "화" },
+  { key: "wed", label: "수" },
+  { key: "thu", label: "목" },
+  { key: "fri", label: "금" },
+  { key: "sat", label: "토" },
+  { key: "sun", label: "일" },
+];
+
+export const initialBusinessHourFormValue: BusinessHourFormValue = {
+  openTime: "",
+  closeTime: "",
+  hasBreakTime: null,
+  breakStartTime: "",
+  breakEndTime: "",
+};

--- a/apps/owner/src/app/signup/register/_types/register.ts
+++ b/apps/owner/src/app/signup/register/_types/register.ts
@@ -16,4 +16,32 @@ export type RandomBoxItem = {
   limit: number;
 };
 
+export interface RandomBoxFormValue {
+  name: string;
+  quantity: number;
+  limit: number;
+  pickupStartTime: string;
+  pickupEndTime: string;
+  description: string;
+}
+
 export type AccountType = "bank" | "holder";
+
+export type DayKey =
+  | "mon"
+  | "tue"
+  | "wed"
+  | "thu"
+  | "fri"
+  | "sat"
+  | "sun";
+
+export type BreakTimeOption = "yes" | "no";
+
+export interface BusinessHourFormValue {
+  openTime: string;
+  closeTime: string;
+  hasBreakTime: BreakTimeOption | null;
+  breakStartTime: string;
+  breakEndTime: string;
+}

--- a/apps/owner/src/app/signup/register/page.tsx
+++ b/apps/owner/src/app/signup/register/page.tsx
@@ -11,8 +11,22 @@ import RandomBoxSection from "./_components/sections/RandomBoxSection";
 import PhotoUploadSection from "./_components/sections/PhotoUploadSection";
 import TagSection from "./_components/sections/TagSection";
 import RegisterSubmitButton from "./_components/RegisterSubmitButton";
-import { businessHoursData, dayLabelMap, orderedDays, initialRandomBoxes, tagOptions } from "./_constants/register";
-import type { AccountType, RandomBoxItem } from "./_types/register";
+import BusinessHoursModal from "./_components/modals/BusinessHoursModal";
+import RandomBoxModal from "./_components/modals/RandomBoxModal";
+
+import {
+  businessHoursData,
+  dayLabelMap,
+  orderedDays,
+  initialRandomBoxes,
+  tagOptions,
+} from "./_constants/register";
+
+import type {
+  AccountType,
+  RandomBoxItem,
+  RandomBoxFormValue,
+} from "./_types/register";
 
 export default function StoreRegisterPage() {
   const router = useRouter();
@@ -22,9 +36,13 @@ export default function StoreRegisterPage() {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [randomBoxes, setRandomBoxes] =
     useState<RandomBoxItem[]>(initialRandomBoxes);
-  const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>(
-    []
-  );
+  const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>([]);
+  const [isBusinessHoursModalOpen, setIsBusinessHoursModalOpen] =
+    useState(false);
+  const [isRandomBoxModalOpen, setIsRandomBoxModalOpen] = useState(false);
+
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string>("");
 
   const businessHoursRows = useMemo(() => {
     return orderedDays.map((day) => {
@@ -61,7 +79,15 @@ export default function StoreRegisterPage() {
     setSelectedRandomBoxIds([]);
   };
 
-  const handleAddRandomBox = () => {
+  const handleOpenRandomBoxModal = () => {
+    setIsRandomBoxModalOpen(true);
+  };
+
+  const handleCloseRandomBoxModal = () => {
+    setIsRandomBoxModalOpen(false);
+  };
+
+  const handleSubmitRandomBox = (data: RandomBoxFormValue) => {
     const nextId =
       randomBoxes.length > 0
         ? Math.max(...randomBoxes.map((item) => item.id)) + 1
@@ -71,62 +97,98 @@ export default function StoreRegisterPage() {
       ...prev,
       {
         id: nextId,
-        name: `Level.${nextId}`,
-        quantity: 1,
-        price: 5000 * nextId,
-        limit: 1,
+        name: data.name,
+        quantity: data.quantity,
+        price: 0,
+        limit: data.limit,
+        pickupStartTime: data.pickupStartTime,
+        pickupEndTime: data.pickupEndTime,
+        description: data.description,
       },
     ]);
   };
 
   const handleOpenBusinessHoursModal = () => {
-    console.log("영업시간 등록 모달 오픈");
+    setIsBusinessHoursModalOpen(true);
+  };
+
+  const handleCloseBusinessHoursModal = () => {
+    setIsBusinessHoursModalOpen(false);
+  };
+
+  const handleSubmitBusinessHours = (data: any) => {
+    console.log("영업시간 등록", data);
   };
 
   const handleSearchAddress = () => {
     console.log("주소 검색");
   };
 
+  const handleChangePhoto = (file: File) => {
+    setPhotoFile(file);
+
+    const objectUrl = URL.createObjectURL(file);
+    setPhotoPreviewUrl(objectUrl);
+  };
+
   const handleCompleteRegister = () => {
+    console.log("업로드 파일", photoFile);
     router.push("/main");
   };
 
   return (
-    <main className="flex w-full flex-col bg-white">
-      <section className="min-h-0 flex-1 overflow-y-auto px-[1.6rem]">
-        <div className="pb-[3.6rem]">
-          <StoreNameField />
-          <EmailField />
-          <StoreAddressField onSearchAddress={handleSearchAddress} />
-          <AccountField
-            selectedAccountType={selectedAccountType}
-            onSelectAccountType={setSelectedAccountType}
-          />
+    <>
+      <main className="flex w-full flex-col bg-white">
+        <section className="min-h-0 flex-1 overflow-y-auto px-[1.6rem]">
+          <div className="pb-[3.6rem]">
+            <StoreNameField />
+            <EmailField />
+            <StoreAddressField onSearchAddress={handleSearchAddress} />
+            <AccountField
+              selectedAccountType={selectedAccountType}
+              onSelectAccountType={setSelectedAccountType}
+            />
 
-          <BusinessHoursSection
-            businessHoursRows={businessHoursRows}
-            onOpenBusinessHoursModal={handleOpenBusinessHoursModal}
-          />
+            <BusinessHoursSection
+              businessHoursRows={businessHoursRows}
+              onOpenBusinessHoursModal={handleOpenBusinessHoursModal}
+            />
 
-          <RandomBoxSection
-            randomBoxes={randomBoxes}
-            selectedRandomBoxIds={selectedRandomBoxIds}
-            onToggleRandomBoxSelection={toggleRandomBoxSelection}
-            onDeleteRandomBoxes={handleDeleteRandomBoxes}
-            onAddRandomBox={handleAddRandomBox}
-          />
+            <RandomBoxSection
+              randomBoxes={randomBoxes}
+              selectedRandomBoxIds={selectedRandomBoxIds}
+              onToggleRandomBoxSelection={toggleRandomBoxSelection}
+              onDeleteRandomBoxes={handleDeleteRandomBoxes}
+              onAddRandomBox={handleOpenRandomBoxModal}
+            />
 
-          <PhotoUploadSection />
+            <PhotoUploadSection
+              previewUrl={photoPreviewUrl}
+              onChangePhoto={handleChangePhoto}
+            />
 
-          <TagSection
-            tagOptions={tagOptions}
-            selectedTags={selectedTags}
-            onToggleTag={toggleTag}
-          />
-        </div>
-      </section>
+            <TagSection
+              tagOptions={tagOptions}
+              selectedTags={selectedTags}
+              onToggleTag={toggleTag}
+            />
+          </div>
+        </section>
 
-      <RegisterSubmitButton onClick={handleCompleteRegister} />
-    </main>
+        <RegisterSubmitButton onClick={handleCompleteRegister} />
+      </main>
+
+      <BusinessHoursModal
+        open={isBusinessHoursModalOpen}
+        onClose={handleCloseBusinessHoursModal}
+        onSubmit={handleSubmitBusinessHours}
+      />
+
+      <RandomBoxModal
+        open={isRandomBoxModalOpen}
+        onClose={handleCloseRandomBoxModal}
+        onSubmit={handleSubmitRandomBox}
+      />
+    </>
   );
 }

--- a/packages/design-system/src/components/Input/Input.tsx
+++ b/packages/design-system/src/components/Input/Input.tsx
@@ -10,6 +10,7 @@ export const Input = ({
   errorMessage,
   className,
   inputClassName,
+  containerClassName,
   disabled = false,
   showPasswordToggle = true,
   inputStyle = "default",
@@ -24,14 +25,14 @@ export const Input = ({
   const currentType =
     isPasswordInput && isPasswordVisible ? "text" : type;
 
-  const containerClassName = isAddressInput
+  const baseContainerClassName = isAddressInput
     ? "rounded-[999px] bg-gray-200"
     : cn(
-      "rounded-[8px] border",
-      error
-        ? "border-accent"
-        : "border-gray-500 focus-within:border-primary"
-    );
+        "rounded-[8px] border",
+        error
+          ? "border-accent"
+          : "border-gray-500 focus-within:border-primary"
+      );
 
   const inputFieldClassName = isAddressInput
     ? "rounded-[999px] bg-gray-200 px-[1rem] py-[1rem]"
@@ -42,6 +43,7 @@ export const Input = ({
       <div
         className={cn(
           "flex w-full items-center transition-colors",
+          baseContainerClassName,
           containerClassName,
           disabled && "cursor-not-allowed opacity-60"
         )}

--- a/packages/design-system/src/components/Input/Input.tsx
+++ b/packages/design-system/src/components/Input/Input.tsx
@@ -28,11 +28,11 @@ export const Input = ({
   const baseContainerClassName = isAddressInput
     ? "rounded-[999px] bg-gray-200"
     : cn(
-        "rounded-[8px] border",
-        error
-          ? "border-accent"
-          : "border-gray-500 focus-within:border-primary"
-      );
+      "rounded-[8px] border",
+      error
+        ? "border-accent"
+        : "border-gray-500 focus-within:border-primary"
+    );
 
   const inputFieldClassName = isAddressInput
     ? "rounded-[999px] bg-gray-200 px-[1rem] py-[1rem]"

--- a/packages/design-system/src/components/Input/Input.types.ts
+++ b/packages/design-system/src/components/Input/Input.types.ts
@@ -1,5 +1,9 @@
+import type { InputHTMLAttributes } from "react";
+
+export type InputStyle = "default" | "address";
+
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "className"> {
   error?: boolean;
   errorMessage?: string;
   className?: string;
@@ -7,5 +11,5 @@ export interface InputProps
   containerClassName?: string;
   disabled?: boolean;
   showPasswordToggle?: boolean;
-  inputStyle?: "default" | "address";
+  inputStyle?: InputStyle;
 }

--- a/packages/design-system/src/components/Input/Input.types.ts
+++ b/packages/design-system/src/components/Input/Input.types.ts
@@ -1,13 +1,11 @@
-import type { InputHTMLAttributes } from "react";
-
-export type InputStyle = "default" | "address";
-
 export interface InputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "className"> {
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
   errorMessage?: string;
   className?: string;
   inputClassName?: string;
+  containerClassName?: string;
+  disabled?: boolean;
   showPasswordToggle?: boolean;
-  inputStyle?: InputStyle;
+  inputStyle?: "default" | "address";
 }


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
> 상점 등록 페이지에서 영업시간 등록 모달과 랜덤박스 등록 모달을 추가하고, 각 모달에서 필요한 입력 흐름과 공통 입력 컴포넌트 확장을 반영했습니다.

> 작업한 내용을 체크해주세요.
- [x] 영업시간 등록 모달 UI 및 열기/닫기 흐름 연결
- [x] 랜덤박스 등록 모달 UI 및 열기/닫기 흐름 연결
- [x] 랜덤박스 이름 / 수량 / 구매 제한 개수 / 픽업 시간 / 설명란 입력 구성
- [x] CountStepper 컴포넌트 추가
- [x] TimeRangeField 재사용하여 픽업 시간 입력 연결
- [x] Input 컴포넌트에 containerClassName 확장
- [x] 모달별 내부 여백, 간격, 정렬 스타일 반영

## 🚀 설계 의도 및 개선점
> 구조 변경 이유 + 고민 + 해결 과정

- 상점 등록 과정에서 영업시간과 랜덤박스 정보를 각각 독립된 입력 흐름으로 분리하기 위해 모달 구조를 추가했습니다.
- 영업시간 모달과 랜덤박스 모달 모두 동일한 Modal 컴포넌트를 기반으로 구성해 UI 일관성을 유지했습니다.
- 랜덤박스 모달은 항목이 많아 정렬이 어긋나기 쉬워, 첫 번째 입력창 시작선을 기준으로 다른 컨트롤들의 배치가 맞도록 레이아웃을 조정했습니다.
- 수량/구매 제한 개수는 단순 input보다 stepper 방식이 더 적합해 CountStepper로 분리해 재사용 가능하게 구성했습니다.
- 기존 Input 컴포넌트만으로는 모달별 border 스타일 제어가 어려워 containerClassName을 추가해 확장성을 높였습니다.
- 향후 수정 모달이나 상세 편집 화면에서도 동일한 입력 컴포넌트 구조를 재사용할 수 있도록 모달 내부 필드를 역할별로 분리 가능한 방향으로 정리했습니다.

### 📸 스크린샷 (선택)
- 영업시간 등록 모달
- 랜덤박스 등록 모달

### 📎 기타 참고사항
- 현재 랜덤박스 추가는 모달 입력값을 기반으로 로컬 상태에 반영되는 방식으로 연결
- Input 공통 컴포넌트 확장으로 모달별 테두리 스타일 커스터마이징 가능
- API 연동 전 단계로, 등록 완료 시점의 서버 전송 로직은 추후 연결 예정

Fixes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주간 영업시간 입력 모달 추가
  * 랜덤박스 생성 모달 추가
  * 이미지 업로드 시 미리보기 기능 추가
  * 수량 조절용 스텝퍼 컴포넌트 추가
  * 시간 범위 선택 UI(타임픽커) 추가

* **개선 사항**
  * 입력 컴포넌트에 컨테이너 스타일 커스터마이즈 옵션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->