### PR TITLE
[Feat/#55] 사장님 주문 현황 페이지 생성

### DIFF
--- a/apps/owner/src/app/(tabs)/order/_components/OrderHistoryCard.tsx
+++ b/apps/owner/src/app/(tabs)/order/_components/OrderHistoryCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Card } from "@compasser/design-system";
+import type { ReservationItem } from "../_types/order";
+import { getStatusClassName, getStatusLabel } from "../_utils/orderStatus";
+
+interface OrderHistoryCardProps {
+  order: ReservationItem;
+}
+
+export default function OrderHistoryCard({ order }: OrderHistoryCardProps) {
+  return (
+    <Card variant="default-black-shadow" className="w-full px-[1.6rem] py-[1.4rem]">
+      <div className="flex flex-col">
+        <div className="grid grid-cols-[7.2rem_1fr_auto] gap-y-[0.4rem] items-start">
+          <span className="body1-m text-gray-700">주문자</span>
+          <span className="body1-m text-default">{order.customerName}</span>
+          <span className={getStatusClassName(order.status)}>
+            {getStatusLabel(order.status)}
+          </span>
+
+          <span className="body1-m text-gray-700">주문내역</span>
+          <span className="body1-m text-default col-span-2">{order.orderDetail}</span>
+
+          <span className="body1-m text-gray-700">가격</span>
+          <span className="body1-m text-default col-span-2">{order.price}</span>
+
+          <span className="body1-m text-gray-700">수량</span>
+          <span className="body1-m text-default col-span-2">{order.quantity}</span>
+        </div>
+
+        <div className="mt-[1.6rem] flex justify-end">
+          <span className="body2-m text-gray-700">{order.processedAt}</span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/owner/src/app/(tabs)/order/_components/OrderList.tsx
+++ b/apps/owner/src/app/(tabs)/order/_components/OrderList.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import ReservationCard from "./ReservationCard";
+import OrderHistoryCard from "./OrderHistoryCard";
+import type { OrderTabKey, ReservationItem } from "../_types/order";
+
+interface OrderListProps {
+  activeTab: OrderTabKey;
+  orders: ReservationItem[];
+  onAccept: (orderId: number) => void;
+  onReject: (orderId: number) => void;
+}
+
+export default function OrderList({
+  activeTab,
+  orders,
+  onAccept,
+  onReject,
+}: OrderListProps) {
+  if (orders.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="body1-m text-gray-600">주문 내역이 없어요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-[1.2rem]">
+      {activeTab === "reservation"
+        ? orders.map((order) => (
+          <ReservationCard
+            key={order.id}
+            order={order}
+            onAccept={onAccept}
+            onReject={onReject}
+          />
+        ))
+        : orders.map((order) => (
+          <OrderHistoryCard key={order.id} order={order} />
+        ))}
+    </div>
+  );
+}

--- a/apps/owner/src/app/(tabs)/order/_components/ReservationCard.tsx
+++ b/apps/owner/src/app/(tabs)/order/_components/ReservationCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Card, Button } from "@compasser/design-system";
+import type { ReservationItem } from "../_types/order";
+import { getStatusClassName, getStatusLabel } from "../_utils/orderStatus";
+
+interface ReservationCardProps {
+  order: ReservationItem;
+  onAccept: (orderId: number) => void;
+  onReject: (orderId: number) => void;
+}
+
+export default function ReservationCard({
+  order,
+  onAccept,
+  onReject,
+}: ReservationCardProps) {
+  const isPending = order.status === "pending";
+
+  return (
+    <Card variant="default-black-shadow" className="w-full px-[1.6rem] py-[1.4rem]">
+      <div className="flex flex-col">
+        <div className="grid grid-cols-[7.2rem_1fr_auto] gap-y-[0.4rem] items-start">
+          <span className="body1-m text-gray-700">주문자</span>
+          <span className="body1-m text-default">{order.customerName}</span>
+          <span className={getStatusClassName(order.status)}>
+            {getStatusLabel(order.status)}
+          </span>
+
+          <span className="body1-m text-gray-700">주문내역</span>
+          <span className="body1-m text-default col-span-2">{order.orderDetail}</span>
+
+          <span className="body1-m text-gray-700">가격</span>
+          <span className="body1-m text-default col-span-2">{order.price}</span>
+
+          <span className="body1-m text-gray-700">수량</span>
+          <span className="body1-m text-default col-span-2">{order.quantity}</span>
+        </div>
+
+        {isPending ? (
+          <div className="mt-[1.6rem] flex items-center gap-[1rem]">
+            <Button
+              type="button"
+              kind="simple"
+              variant="outline-primary"
+              fullWidth={false}
+              onClick={() => onAccept(order.id)}
+            >
+              수락
+            </Button>
+
+            <Button
+              type="button"
+              kind="simple"
+              variant="outline-gray"
+              fullWidth={false}
+              onClick={() => onReject(order.id)}
+            >
+              거절
+            </Button>
+          </div>
+        ) : (
+          <div className="mt-[1.6rem] flex justify-end">
+            <span className="body2-m text-gray-700">{order.processedAt}</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/owner/src/app/(tabs)/order/_components/modal/AcceptOrderModal.tsx
+++ b/apps/owner/src/app/(tabs)/order/_components/modal/AcceptOrderModal.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Button, Modal } from "@compasser/design-system";
+
+interface AcceptOrderModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function AcceptOrderModal({
+  open,
+  onClose,
+  onConfirm,
+}: AcceptOrderModalProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="confirm"
+      title="주문을 수락하시겠습니까?"
+      bodyClassName="mt-0"
+      footerClassName="mt-[2rem]"
+      footer={
+        <div className="flex items-center justify-center gap-[2rem]">
+          <Button
+            size="sm"
+            variant="gray"
+            fullWidth={false}
+            className="px-[2.2rem]"
+            onClick={onClose}
+          >
+            그만두기
+          </Button>
+
+          <Button
+            size="sm"
+            variant="primary"
+            fullWidth={false}
+            className="px-[2.2rem]"
+            onClick={onConfirm}
+          >
+            수락하기
+          </Button>
+        </div>
+      }
+    />
+  );
+}

--- a/apps/owner/src/app/(tabs)/order/_components/modal/RejectOrderModal.tsx
+++ b/apps/owner/src/app/(tabs)/order/_components/modal/RejectOrderModal.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button, Modal } from "@compasser/design-system";
+
+interface RejectOrderModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (reason: string) => void;
+}
+
+export default function RejectOrderModal({
+  open,
+  onClose,
+  onConfirm,
+}: RejectOrderModalProps) {
+  const [reason, setReason] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setReason("");
+    }
+  }, [open]);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="confirm"
+      title="주문을 거절하시겠습니까?"
+      bodyClassName="mt-0"
+      footerClassName="mt-[1.6rem]"
+      footer={
+        <div className="flex items-center justify-center gap-[2rem]">
+          <Button
+            size="sm"
+            variant="gray"
+            fullWidth={false}
+            className="px-[2.2rem]"
+            onClick={onClose}
+          >
+            그만두기
+          </Button>
+
+          <Button
+            size="sm"
+            variant="primary"
+            fullWidth={false}
+            className="px-[2.2rem]"
+            onClick={() => onConfirm(reason)}
+          >
+            거절하기
+          </Button>
+        </div>
+      }
+    >
+      <div className="my-[1.6rem]">
+        <input
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="거절 사유를 입력해주세요."
+          className="
+            w-full rounded-[8px] border border-primary
+            px-[1rem] py-[0.6rem]
+            body2-r text-default
+            placeholder:body2-r placeholder:text-gray-300
+            outline-none
+          "
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/apps/owner/src/app/(tabs)/order/_constants/mockOrders.ts
+++ b/apps/owner/src/app/(tabs)/order/_constants/mockOrders.ts
@@ -1,0 +1,36 @@
+import type { ReservationItem } from "../_types/order";
+
+export const INITIAL_RESERVATIONS: ReservationItem[] = [
+  {
+    id: 1,
+    customerName: "김00",
+    orderDetail: "랜덤박스 1레벨",
+    price: "6,000원",
+    quantity: "1개",
+    status: "pending",
+  },
+  {
+    id: 2,
+    customerName: "고00",
+    orderDetail: "랜덤박스 1레벨",
+    price: "6,000원",
+    quantity: "1개",
+    status: "pending",
+  },
+  {
+    id: 3,
+    customerName: "이00",
+    orderDetail: "랜덤박스 3레벨",
+    price: "12,000원",
+    quantity: "2개",
+    status: "pending",
+  },
+  {
+    id: 4,
+    customerName: "박00",
+    orderDetail: "랜덤박스 2레벨",
+    price: "9,000원",
+    quantity: "3개",
+    status: "pending",
+  }
+];

--- a/apps/owner/src/app/(tabs)/order/_types/order.ts
+++ b/apps/owner/src/app/(tabs)/order/_types/order.ts
@@ -1,0 +1,23 @@
+export type OrderTabKey = "reservation" | "order";
+
+export type ReservationStatus = "pending" | "completed" | "cancelled";
+
+export interface ReservationItem {
+  id: number;
+  customerName: string;
+  orderDetail: string;
+  price: string;
+  quantity: string;
+  status: ReservationStatus;
+  processedAt?: string;
+}
+
+export interface AcceptModalState {
+  isOpen: boolean;
+  orderId: number | null;
+}
+
+export interface RejectModalState {
+  isOpen: boolean;
+  orderId: number | null;
+}

--- a/apps/owner/src/app/(tabs)/order/_utils/formatProcessAt.ts
+++ b/apps/owner/src/app/(tabs)/order/_utils/formatProcessAt.ts
@@ -1,0 +1,7 @@
+export const formatProcessedAt = (date: Date) => {
+  const year = String(date.getFullYear()).slice(2);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}/${month}/${day}`;
+};

--- a/apps/owner/src/app/(tabs)/order/_utils/orderStatus.ts
+++ b/apps/owner/src/app/(tabs)/order/_utils/orderStatus.ts
@@ -1,0 +1,27 @@
+import type { ReservationStatus } from "../_types/order";
+
+export const getStatusLabel = (status: ReservationStatus) => {
+  switch (status) {
+  case "pending":
+    return "확인 대기중";
+  case "completed":
+    return "거래완료";
+  case "cancelled":
+    return "거래취소";
+  default:
+    return "";
+  }
+};
+
+export const getStatusClassName = (status: ReservationStatus) => {
+  switch (status) {
+  case "pending":
+    return "body1-m text-secondary";
+  case "completed":
+    return "body1-m text-primary";
+  case "cancelled":
+    return "body1-m text-gray-500";
+  default:
+    return "";
+  }
+};

--- a/apps/owner/src/app/(tabs)/order/page.tsx
+++ b/apps/owner/src/app/(tabs)/order/page.tsx
@@ -17,6 +17,8 @@ import type {
 export default function OrderStatusPage() {
   const [activeTab, setActiveTab] = useState<OrderTabKey>("reservation");
   const [orders, setOrders] = useState<ReservationItem[]>(INITIAL_RESERVATIONS);
+  const isOrderTabKey = (key: string): key is OrderTabKey =>
+   key === "reservation" || key === "order";
 
   const [acceptModal, setAcceptModal] = useState<AcceptModalState>({
     isOpen: false,
@@ -120,7 +122,9 @@ export default function OrderStatusPage() {
             { key: "order", label: "주문" },
           ]}
           activeKey={activeTab}
-          onTabChange={(key) => setActiveTab(key as OrderTabKey)}
+          onTabChange={(key) => {
+            if (isOrderTabKey(key)) setActiveTab(key);
+          }}
         />
 
         <section className="flex-1 overflow-y-auto px-[1.6rem] pt-[2.8rem] pb-[10rem]">

--- a/apps/owner/src/app/(tabs)/order/page.tsx
+++ b/apps/owner/src/app/(tabs)/order/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Header, TopTabBar } from "@compasser/design-system";
+import OrderList from "./_components/OrderList";
+import AcceptOrderModal from "./_components/modal/AcceptOrderModal";
+import RejectOrderModal from "./_components/modal/RejectOrderModal";
+import { INITIAL_RESERVATIONS } from "./_constants/mockOrders";
+import { formatProcessedAt } from "./_utils/formatProcessAt";
+import type {
+  AcceptModalState,
+  OrderTabKey,
+  RejectModalState,
+  ReservationItem,
+} from "./_types/order";
+
+export default function OrderStatusPage() {
+  const [activeTab, setActiveTab] = useState<OrderTabKey>("reservation");
+  const [orders, setOrders] = useState<ReservationItem[]>(INITIAL_RESERVATIONS);
+
+  const [acceptModal, setAcceptModal] = useState<AcceptModalState>({
+    isOpen: false,
+    orderId: null,
+  });
+
+  const [rejectModal, setRejectModal] = useState<RejectModalState>({
+    isOpen: false,
+    orderId: null,
+  });
+
+  const reservationOrders = useMemo(
+    () => orders.filter((order) => order.status === "pending"),
+    [orders]
+  );
+
+  const completedOrders = useMemo(
+    () => orders.filter((order) => order.status !== "pending"),
+    [orders]
+  );
+
+  const currentOrders =
+    activeTab === "reservation" ? reservationOrders : completedOrders;
+
+  const openAcceptModal = (orderId: number) => {
+    setAcceptModal({
+      isOpen: true,
+      orderId,
+    });
+  };
+
+  const closeAcceptModal = () => {
+    setAcceptModal({
+      isOpen: false,
+      orderId: null,
+    });
+  };
+
+  const openRejectModal = (orderId: number) => {
+    setRejectModal({
+      isOpen: true,
+      orderId,
+    });
+  };
+
+  const closeRejectModal = () => {
+    setRejectModal({
+      isOpen: false,
+      orderId: null,
+    });
+  };
+
+  const handleAcceptOrder = () => {
+    if (acceptModal.orderId === null) return;
+
+    const now = formatProcessedAt(new Date());
+
+    setOrders((prev) =>
+      prev.map((order) =>
+        order.id === acceptModal.orderId
+          ? {
+            ...order,
+            status: "completed",
+            processedAt: now,
+          }
+          : order
+      )
+    );
+
+    closeAcceptModal();
+  };
+
+  const handleRejectOrder = (_reason: string) => {
+    if (rejectModal.orderId === null) return;
+
+    const now = formatProcessedAt(new Date());
+
+    setOrders((prev) =>
+      prev.map((order) =>
+        order.id === rejectModal.orderId
+          ? {
+            ...order,
+            status: "cancelled",
+            processedAt: now,
+          }
+          : order
+      )
+    );
+
+    closeRejectModal();
+  };
+
+  return (
+    <>
+      <main className="flex min-h-screen flex-col bg-white">
+        <Header variant="center-title-shadow" title="주문 현황" />
+
+        <TopTabBar
+          items={[
+            { key: "reservation", label: "예약" },
+            { key: "order", label: "주문" },
+          ]}
+          activeKey={activeTab}
+          onTabChange={(key) => setActiveTab(key as OrderTabKey)}
+        />
+
+        <section className="flex-1 overflow-y-auto px-[1.6rem] pt-[2.8rem] pb-[10rem]">
+          <OrderList
+            activeTab={activeTab}
+            orders={currentOrders}
+            onAccept={openAcceptModal}
+            onReject={openRejectModal}
+          />
+        </section>
+      </main>
+
+      <AcceptOrderModal
+        open={acceptModal.isOpen}
+        onClose={closeAcceptModal}
+        onConfirm={handleAcceptOrder}
+      />
+
+      <RejectOrderModal
+        open={rejectModal.isOpen}
+        onClose={closeRejectModal}
+        onConfirm={handleRejectOrder}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
> 주문 현황 페이지의 예약/주문 탭 UI를 구현하고, 예약 상태에 따른 수락/거절 모달 및 주문 상태 변경 흐름을 반영했습니다.

> 작업한 내용을 체크해주세요.
- [x] 주문 현황 페이지 헤더 및 탭 구성
- [x] 예약/주문 탭별 카드 UI 분리
- [x] 예약 카드 내 수락/거절 버튼 추가
- [x] 수락/거절 확인 모달 연동
- [x] 처리 결과에 따른 거래완료/거래취소 상태 표시 반영

## 🚀 설계 의도 및 개선점
> 예약 탭과 주문 탭의 역할이 달라 카드 컴포넌트와 상태 흐름을 분리해 관리했습니다.  
> 수락/거절 액션은 모달을 통해 한 번 더 확인하도록 구성했고, 처리 이후에는 상태 텍스트와 처리 일자가 즉시 반영되도록 설계했습니다.

### 📸 스크린샷 (선택)
- 예약 탭 UI

<img width="160" height="351" alt="image" src="https://github.com/user-attachments/assets/924e03ae-62b9-4ad2-9718-979b65f80641" />

<img width="159" height="347" alt="image" src="https://github.com/user-attachments/assets/732b6ee2-7252-4fcd-b700-71c2bd53bb9d" />


### 📎 기타 참고사항
- 목데이터 기반으로 상태 변경 흐름 확인
- 환경 변수 변경 없음

Fixes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 현황 관리 페이지 추가: 예약/주문 탭 네비게이션 및 리스트 제공
  * 예약/주문 카드 UI 추가: 고객정보, 수량/가격, 상태 배지, 처리 시간 표시
  * 대기 중 예약에 대한 수락·거절 모달 및 액션 추가
  * 상태 표시 문자열 및 처리일자 포맷 처리 유틸리티와 초기 샘플 데이터 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->