### PR TITLE
[Feat/#56] 사장님 스토어 계정 및 스토어 정보 수정 페이지 생성

### DIFF
--- a/apps/owner/src/app/(tabs)/mypage/page.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Header, Icon } from "@compasser/design-system";
+
+interface SettingMenuItemProps {
+  label: string;
+  onClick: () => void;
+}
+
+function SettingMenuItem({ label, onClick }: SettingMenuItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center justify-between border-b border-gray-200 px-[1.6rem] py-[1.6rem] text-left"
+    >
+      <span className="body1-r text-default">{label}</span>
+      <Icon
+        name="NextButton"
+        width={20}
+        height={20}
+        ariaHidden={false}
+      />
+    </button>
+  );
+}
+
+export default function MyPageSettingsPage() {
+  const router = useRouter();
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-white">
+      <Header variant="center-title-shadow" title="설정" />
+
+      <div className="flex flex-col">
+        <SettingMenuItem
+          label="스토어 정보 수정"
+          onClick={() => router.push("/mypage/store-info")}
+        />
+
+        <SettingMenuItem
+          label="내 스토어 계정"
+          onClick={() => router.push("/mypage/store-account")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/owner/src/app/(tabs)/mypage/store-account/_components/ConfirmActionModal.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/_components/ConfirmActionModal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Button, Modal } from "@compasser/design-system";
+import type { ConfirmActionModalProps } from "../_types/confirmAction";
+
+export const ConfirmActionModal = ({
+  open,
+  title,
+  cancelText,
+  confirmText,
+  cancelVariant = "gray",
+  confirmVariant = "primary",
+  onClose,
+  onConfirm,
+  reverseButtons = false,
+}: ConfirmActionModalProps) => {
+  const cancelButton = (
+    <Button
+      size="sm"
+      variant={cancelVariant}
+      fullWidth={false}
+      className="px-[2.2rem]"
+      onClick={onClose}
+    >
+      {cancelText}
+    </Button>
+  );
+
+  const confirmButton = (
+    <Button
+      size="sm"
+      variant={confirmVariant}
+      fullWidth={false}
+      className="px-[2.2rem]"
+      onClick={onConfirm}
+    >
+      {confirmText}
+    </Button>
+  );
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="confirm"
+      title={title}
+      bodyClassName="mt-0"
+      footerClassName="mt-[2rem]"
+      footer={
+        <div className="flex items-center justify-center gap-[1.2rem]">
+          {reverseButtons ? (
+            <>
+              {confirmButton}
+              {cancelButton}
+            </>
+          ) : (
+            <>
+              {cancelButton}
+              {confirmButton}
+            </>
+          )}
+        </div>
+      }
+    />
+  );
+};

--- a/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerAccountCard.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerAccountCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@compasser/design-system";
+import { ConfirmActionModal } from "./ConfirmActionModal";
+
+export const OwnerAccountCard = () => {
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
+
+  const handleOpenLogoutModal = () => {
+    setIsLogoutModalOpen(true);
+  };
+
+  const handleCloseLogoutModal = () => {
+    setIsLogoutModalOpen(false);
+  };
+
+  const handleOpenWithdrawModal = () => {
+    setIsWithdrawModalOpen(true);
+  };
+
+  const handleCloseWithdrawModal = () => {
+    setIsWithdrawModalOpen(false);
+  };
+
+  const handleLogout = () => {
+    console.log("로그아웃");
+    setIsLogoutModalOpen(false);
+  };
+
+  const handleWithdraw = () => {
+    console.log("회원탈퇴");
+    setIsWithdrawModalOpen(false);
+  };
+
+  return (
+    <>
+      <Card variant="gray-200-elevated">
+        <div>
+          <p className="body1-m text-primary">내 스토어 계정</p>
+
+          <div className="mt-[0.8rem] border-t border-gray-200 px-[1rem] py-[1rem]">
+            <div className="flex flex-col items-start gap-[1.2rem]">
+              <button
+                type="button"
+                onClick={handleOpenLogoutModal}
+                className="body2-r text-default"
+              >
+                로그아웃
+              </button>
+
+              <button
+                type="button"
+                onClick={handleOpenWithdrawModal}
+                className="body2-r text-default"
+              >
+                회원탈퇴
+              </button>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <ConfirmActionModal
+        open={isLogoutModalOpen}
+        title="로그아웃하시겠습니까?"
+        cancelText="그만두기"
+        confirmText="로그아웃"
+        cancelVariant="gray"
+        confirmVariant="primary"
+        onClose={handleCloseLogoutModal}
+        onConfirm={handleLogout}
+      />
+
+      <ConfirmActionModal
+        open={isWithdrawModalOpen}
+        title="탈퇴하시겠습니까?"
+        cancelText="그만두기"
+        confirmText="탈퇴하기"
+        cancelVariant="gray"
+        confirmVariant="secondary"
+        onClose={handleCloseWithdrawModal}
+        onConfirm={handleWithdraw}
+        reverseButtons={true}
+      />
+    </>
+  );
+};

--- a/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerBusinessNumberCard.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerBusinessNumberCard.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Card } from "@compasser/design-system";
+
+export const OwnerBusinessNumberCard = () => {
+  return (
+    <Card variant="gray-200-elevated">
+      <div>
+        <p className="body1-m text-primary">내 사업자 등록번호</p>
+
+        <div className="mt-[0.8rem] border-t border-gray-200 py-[1rem]">
+          <div className="flex items-center justify-between">
+            <span className="body2-r text-default">사업자 등록번호</span>
+            <span className="body2-r text-gray-600">123-45-67890</span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerProfileSection.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerProfileSection.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Icon } from "@compasser/design-system";
+
+export const OwnerProfileSection = () => {
+  return (
+    <section className="bg-background px-[1.6rem] py-[3.2rem]">
+      <div className="flex items-start">
+        <div className="shrink-0">
+          <Icon
+            name="ProfileCharacter"
+            width={80}
+            height={80}
+            ariaHidden={true}
+          />
+        </div>
+
+        <div className="ml-[0.8rem] min-w-0 body1-m text-default">
+          <p>홍길동</p>
+          <p>루키사장</p>
+          <p>owner@example.com</p>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerStoreAccountInfoCard.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/_components/OwnerStoreAccountInfoCard.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Card, Icon } from "@compasser/design-system";
+
+export const OwnerStoreAccountInfoCard = () => {
+  const router = useRouter();
+
+  const handleMoveStoreInfoPage = () => {
+    router.push("/mypage/store-info");
+  };
+
+  return (
+    <Card variant="gray-200-elevated">
+      <div>
+        <div className="flex items-center justify-between">
+          <p className="body1-m text-primary">내 계좌 정보</p>
+
+          <button
+            type="button"
+            onClick={handleMoveStoreInfoPage}
+            className="flex items-center gap-[0.2rem] text-gray-600"
+          >
+            <span className="body2-m text-gray-600">수정하기</span>
+            <Icon
+              name="NextButton"
+              width={16}
+              height={16}
+              ariaHidden={true}
+            />
+          </button>
+        </div>
+
+        <div className="mt-[0.8rem] border-t border-gray-200 py-[1rem]">
+          <div className="flex flex-col gap-[1.2rem]">
+            <div className="flex items-center justify-between">
+              <span className="body2-r text-default">은행명</span>
+              <span className="body2-r text-gray-600">국민은행</span>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <span className="body2-r text-default">계좌번호</span>
+              <span className="body2-r text-gray-600">
+                123-456-789012
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/apps/owner/src/app/(tabs)/mypage/store-account/_types/confirmAction.ts
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/_types/confirmAction.ts
@@ -1,0 +1,11 @@
+export interface ConfirmActionModalProps {
+  open: boolean;
+  title: string;
+  cancelText: string;
+  confirmText: string;
+  cancelVariant?: "gray" | "primary" | "secondary";
+  confirmVariant?: "gray" | "primary" | "secondary";
+  onClose: () => void;
+  onConfirm: () => void;
+  reverseButtons?: boolean;
+}

--- a/apps/owner/src/app/(tabs)/mypage/store-account/page.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-account/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Header } from "@compasser/design-system";
+import { OwnerAccountCard } from "./_components/OwnerAccountCard";
+import { OwnerBusinessNumberCard } from "./_components/OwnerBusinessNumberCard";
+import { OwnerProfileSection } from "./_components/OwnerProfileSection";
+import { OwnerStoreAccountInfoCard } from "./_components/OwnerStoreAccountInfoCard";
+
+export default function StoreAccountPage() {
+  const router = useRouter();
+
+  return (
+    <main className="flex min-h-dvh flex-col bg-white">
+      <Header
+        variant="back-title"
+        title="내 스토어 계정"
+        onBackClick={() => router.back()}
+      />
+
+      <OwnerProfileSection />
+
+      <section className="flex-1 bg-white px-[1.75rem] pt-[3.2rem] pb-[3.2rem]">
+        <div className="flex flex-col gap-[2rem]">
+          <OwnerAccountCard />
+          <OwnerStoreAccountInfoCard />
+          <OwnerBusinessNumberCard />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/owner/src/app/(tabs)/mypage/store-info/page.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-info/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import StoreNameField from "@/app/signup/register/_components/fields/StoreNameField";
+import EmailField from "@/app/signup/register/_components/fields/EmailField";
+import StoreAddressField from "@/app/signup/register/_components/fields/StoreAddressField";
+import AccountField from "@/app/signup/register/_components/fields/AccountField";
+import BusinessHoursSection from "@/app/signup/register/_components/sections/BusinessHoursSection";
+import RandomBoxSection from "@/app/signup/register/_components/sections/RandomBoxSection";
+import PhotoUploadSection from "@/app/signup/register/_components/sections/PhotoUploadSection";
+import TagSection from "@/app/signup/register/_components/sections/TagSection";
+import BusinessHoursModal from "@/app/signup/register/_components/modals/BusinessHoursModal";
+import RandomBoxModal from "@/app/signup/register/_components/modals/RandomBoxModal";
+import { Button, Header } from "@compasser/design-system";
+
+import {
+  businessHoursData,
+  dayLabelMap,
+  orderedDays,
+  initialRandomBoxes,
+  tagOptions,
+} from "@/app/signup/register/_constants/register";
+
+import type {
+  AccountType,
+  RandomBoxItem,
+  RandomBoxFormValue,
+} from "@/app/signup/register/_types/register";
+
+export default function StoreInfoEditPage() {
+  const router = useRouter();
+
+  const [selectedAccountType, setSelectedAccountType] =
+    useState<AccountType | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [randomBoxes, setRandomBoxes] =
+    useState<RandomBoxItem[]>(initialRandomBoxes);
+  const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>([]);
+  const [isBusinessHoursModalOpen, setIsBusinessHoursModalOpen] =
+    useState(false);
+  const [isRandomBoxModalOpen, setIsRandomBoxModalOpen] = useState(false);
+
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string>("");
+
+  const businessHoursRows = useMemo(() => {
+    return orderedDays.map((day) => {
+      const value = businessHoursData[day];
+      const formatted = value === "closed" ? "휴무" : value.replace("-", " ~ ");
+
+      return {
+        dayLabel: dayLabelMap[day],
+        time: formatted,
+      };
+    });
+  }, []);
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag)
+        ? prev.filter((item) => item !== tag)
+        : [...prev, tag]
+    );
+  };
+
+  const toggleRandomBoxSelection = (id: number) => {
+    setSelectedRandomBoxIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((item) => item !== id)
+        : [...prev, id]
+    );
+  };
+
+  const handleDeleteRandomBoxes = () => {
+    setRandomBoxes((prev) =>
+      prev.filter((item) => !selectedRandomBoxIds.includes(item.id))
+    );
+    setSelectedRandomBoxIds([]);
+  };
+
+  const handleOpenRandomBoxModal = () => {
+    setIsRandomBoxModalOpen(true);
+  };
+
+  const handleCloseRandomBoxModal = () => {
+    setIsRandomBoxModalOpen(false);
+  };
+
+  const handleSubmitRandomBox = (data: RandomBoxFormValue) => {
+    const nextId =
+      randomBoxes.length > 0
+        ? Math.max(...randomBoxes.map((item) => item.id)) + 1
+        : 1;
+
+    setRandomBoxes((prev) => [
+      ...prev,
+      {
+        id: nextId,
+        name: data.name,
+        quantity: data.quantity,
+        price: 0,
+        limit: data.limit,
+        pickupStartTime: data.pickupStartTime,
+        pickupEndTime: data.pickupEndTime,
+        description: data.description,
+      },
+    ]);
+  };
+
+  const handleOpenBusinessHoursModal = () => {
+    setIsBusinessHoursModalOpen(true);
+  };
+
+  const handleCloseBusinessHoursModal = () => {
+    setIsBusinessHoursModalOpen(false);
+  };
+
+  const handleSubmitBusinessHours = (data: any) => {
+    console.log("영업시간 수정", data);
+  };
+
+  const handleSearchAddress = () => {
+    console.log("주소 검색");
+  };
+
+  const handleChangePhoto = (file: File) => {
+    setPhotoFile(file);
+
+    const objectUrl = URL.createObjectURL(file);
+    setPhotoPreviewUrl(objectUrl);
+  };
+
+  const handleCompleteEdit = () => {
+    console.log("수정 파일", photoFile);
+    router.push("/mypage");
+  };
+
+  return (
+    <>
+      <div className="flex min-h-dvh flex-col bg-white">
+        <Header
+          variant="back-title"
+          title="스토어 정보 수정"
+          onBackClick={() => router.back()}
+        />
+
+        <main className="flex min-h-0 flex-1 flex-col bg-white">
+          <section className="min-h-0 flex-1 overflow-y-auto px-[1.6rem]">
+            <div className="pb-[3.6rem] pt-[1.6rem]">
+              <StoreNameField />
+              <EmailField />
+              <StoreAddressField onSearchAddress={handleSearchAddress} />
+              <AccountField
+                selectedAccountType={selectedAccountType}
+                onSelectAccountType={setSelectedAccountType}
+              />
+
+              <BusinessHoursSection
+                businessHoursRows={businessHoursRows}
+                onOpenBusinessHoursModal={handleOpenBusinessHoursModal}
+              />
+
+              <RandomBoxSection
+                randomBoxes={randomBoxes}
+                selectedRandomBoxIds={selectedRandomBoxIds}
+                onToggleRandomBoxSelection={toggleRandomBoxSelection}
+                onDeleteRandomBoxes={handleDeleteRandomBoxes}
+                onAddRandomBox={handleOpenRandomBoxModal}
+              />
+
+              <PhotoUploadSection
+                previewUrl={photoPreviewUrl}
+                onChangePhoto={handleChangePhoto}
+              />
+
+              <TagSection
+                tagOptions={tagOptions}
+                selectedTags={selectedTags}
+                onToggleTag={toggleTag}
+              />
+            </div>
+          </section>
+
+          <div className="shrink-0 px-[1.6rem] pt-[1.6rem] pb-[8rem]">
+            <Button
+              type="button"
+              size="lg"
+              kind="default"
+              variant="primary"
+              onClick={handleCompleteEdit}
+            >
+              수정 완료하기
+            </Button>
+          </div>
+        </main>
+      </div>
+
+      <BusinessHoursModal
+        open={isBusinessHoursModalOpen}
+        onClose={handleCloseBusinessHoursModal}
+        onSubmit={handleSubmitBusinessHours}
+      />
+
+      <RandomBoxModal
+        open={isRandomBoxModalOpen}
+        onClose={handleCloseRandomBoxModal}
+        onSubmit={handleSubmitRandomBox}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
- 마이페이지 > 설정 흐름 구현
- 스토어 정보 수정 페이지 추가 (기존 등록 페이지 UI 재사용)
- 내 스토어 계정 페이지 UI 구성 (프로필 + 3개 카드)
- 공통 Header(back-title) 적용 및 라우팅 연결

> 작업한 내용을 체크해주세요.
- [x] 설정 화면 UI 및 이동 연결
- [x] 스토어 정보 수정 페이지 구현
- [x] 내 스토어 계정 페이지 구현
- [x] 공통 Header 적용

## 🚀 설계 의도 및 개선점
- 기존 스토어 등록 UI를 그대로 재사용하여 빠른 구현
- 디자인 시스템(Card, Header, Button) 기반으로 일관된 UI 유지
- 페이지 단위로 우선 구현 후, 추후 공통 Form 구조로 리팩토링 예정

### 📸 스크린샷 (선택)
- 사장님 설정 페이지, 사장님 스토어 계정 페이지, 사장님 스토어 정보 수정 페이지

<img width="162" height="349" alt="image" src="https://github.com/user-attachments/assets/dbc21ed1-9db8-401b-955d-f3bb71773526" />

<img width="160" height="353" alt="image" src="https://github.com/user-attachments/assets/121fb5f8-5996-486f-908a-ec039494d44a" />

<img width="162" height="352" alt="image" src="https://github.com/user-attachments/assets/6fa7eb45-0200-4db4-afd4-92486de1ad28" />
 

### 📎 기타 참고사항
- 현재는 UI 중심 구현, API 및 상태 분리는 추후 진행 예정


Fixes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이페이지 설정 화면 추가
  * 스토어 계정 관리 기능 (로그아웃, 회원탈퇴)
  * 스토어 정보 수정 페이지 추가 - 영업시간, 상품 박스, 사진 업로드, 태그 관리 기능 포함
  * 계좌 정보 및 사업자 등록번호 조회 기능 추가
  * 확인 모달 컴포넌트 추가로 사용자 액션 검증 기능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->