### PR TITLE
[Feat/#91] 사장님 QR 촬영 API 연동

### DIFF
--- a/apps/owner/src/app/(tabs)/main/_components/CafeIntro.tsx
+++ b/apps/owner/src/app/(tabs)/main/_components/CafeIntro.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from "react";
 import { Icon } from "@compasser/design-system";
+import type { GetMemberRewardDTO } from "@compasser/api";
 import QRStampModal from "./QRStampModal";
+import QRRewardConfirmModal from "./QRRewardConfirmModal";
+import { useWritingRewardMutation } from "@/shared/queries/mutation/store-manager/useQrMutation";
 
 interface CafeIntroProps {
   cafeName: string;
@@ -29,13 +32,18 @@ const formatCafeName = (name: string) => {
 
   return {
     firstLine: name.slice(0, 10).trim(),
-      secondLine: name.slice(10).trim(),
+    secondLine: name.slice(10).trim(),
   };
 };
 
 export default function CafeIntro({ cafeName }: CafeIntroProps) {
   const { firstLine, secondLine } = formatCafeName(cafeName);
+
   const [isQrModalOpen, setIsQrModalOpen] = useState(false);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [rewardInfo, setRewardInfo] = useState<GetMemberRewardDTO | null>(null);
+
+  const writingRewardMutation = useWritingRewardMutation();
 
   const handleOpenQrModal = () => {
     setIsQrModalOpen(true);
@@ -45,8 +53,28 @@ export default function CafeIntro({ cafeName }: CafeIntroProps) {
     setIsQrModalOpen(false);
   };
 
-  const handleSubmitStamp = () => {
-    console.log("적립하기");
+  const handleQrSuccess = (data: GetMemberRewardDTO) => {
+    setRewardInfo(data);
+    setIsQrModalOpen(false);
+    setIsConfirmModalOpen(true);
+  };
+
+  const handleCloseConfirmModal = () => {
+    setIsConfirmModalOpen(false);
+    setRewardInfo(null);
+  };
+
+  const handleConfirmReward = async () => {
+    if (!rewardInfo) return;
+
+    await writingRewardMutation.mutateAsync({
+      rewardId: rewardInfo.rewardId,
+      storeId: rewardInfo.storeId,
+      memberId: rewardInfo.memberId,
+    });
+
+    setIsConfirmModalOpen(false);
+    setRewardInfo(null);
   };
 
   return (
@@ -81,7 +109,26 @@ export default function CafeIntro({ cafeName }: CafeIntroProps) {
       <QRStampModal
         open={isQrModalOpen}
         onClose={handleCloseQrModal}
-        onSubmit={handleSubmitStamp}
+        onSuccess={handleQrSuccess}
+      />
+
+      <QRRewardConfirmModal
+        open={isConfirmModalOpen}
+        onClose={handleCloseConfirmModal}
+        onConfirm={handleConfirmReward}
+        isPending={writingRewardMutation.isPending}
+        info={
+          rewardInfo
+            ? {
+                nickname: rewardInfo.nickname,
+                email: rewardInfo.email,
+                randomBoxName: rewardInfo.randomBoxName,
+                totalPrice: rewardInfo.totalPrice,
+                stamp: rewardInfo.stamp,
+                coupon: rewardInfo.coupon,
+              }
+            : null
+        }
       />
     </>
   );

--- a/apps/owner/src/app/(tabs)/main/_components/QRRewardConfirmModal.tsx
+++ b/apps/owner/src/app/(tabs)/main/_components/QRRewardConfirmModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+interface QRRewardConfirmModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+  info: {
+    nickname: string;
+    email: string;
+    randomBoxName: string;
+    totalPrice: number;
+    stamp: number;
+    coupon: number;
+  } | null;
+}
+
+const MAX_STAMP_COUNT = 10;
+
+const formatPrice = (price: number) => `${price.toLocaleString()}원`;
+
+export default function QRRewardConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  isPending = false,
+  info,
+}: QRRewardConfirmModalProps) {
+  if (!open || !info) return null;
+
+  const currentStamp = Math.max(0, Math.min(info.stamp, MAX_STAMP_COUNT));
+
+  return (
+    <div
+      className="fixed inset-0 z-[1000] bg-default/50 px-[2.75rem]"
+      onClick={onClose}
+    >
+      <div className="flex h-full items-center justify-center">
+        <div
+          className="w-full rounded-[10px] border border-primary bg-background px-[1rem] py-[2rem]"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex min-w-0 items-center">
+              <p className="shrink-0 head3-m text-default">
+                {info.nickname}님
+              </p>
+              <p className="ml-[0.4rem] min-w-0 truncate body2-m text-gray-600">
+                {info.email}
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={isPending}
+              className="shrink-0 rounded-[999px] border-[1.5px] border-primary px-[2rem] py-[0.8rem] body1-m text-primary disabled:opacity-50"
+            >
+              {isPending ? "적립 중" : "적립"}
+            </button>
+          </div>
+
+          <div className="mt-[1rem] grid grid-cols-[max-content_1fr] gap-x-[4.2rem] gap-y-[1rem]">
+            <p className="body1-m text-gray-700">주문내역</p>
+            <p className="body1-m text-gray-700">{info.randomBoxName}</p>
+
+            <p className="body1-m text-gray-700">가격</p>
+            <p className="body1-m text-gray-700">
+              {formatPrice(info.totalPrice)}
+            </p>
+
+            <p className="body1-m text-gray-700">적립수</p>
+            <p className="body1-m text-gray-700">{info.coupon}개</p>
+
+            <p className="body1-m text-gray-700">도장 현황</p>
+            <div className="flex items-end">
+              <span className="head3-m text-primary">{currentStamp}</span>
+              <span className="body2-m text-gray-700">/10</span>
+            </div>
+          </div>
+
+          <div className="mt-[0.8rem] flex w-full gap-[0.2rem]">
+            {Array.from({ length: MAX_STAMP_COUNT }).map((_, index) => (
+              <div
+                key={index}
+                className={`h-[10px] flex-1 rounded-full ${
+                  index < currentStamp ? "bg-primary" : "bg-gray-200"
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/owner/src/app/(tabs)/main/_components/QRStampModal.tsx
+++ b/apps/owner/src/app/(tabs)/main/_components/QRStampModal.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "@compasser/design-system";
+import type { GetMemberRewardDTO } from "@compasser/api";
+import { useCheckQrMutation } from "@/shared/queries/mutation/store-manager/useQrMutation";
 
 interface QRStampModalProps {
   open: boolean;
   onClose: () => void;
-  onSubmit?: () => void;
+  onSuccess: (data: GetMemberRewardDTO) => void;
 }
 
 interface CornerGuideProps {
@@ -14,23 +16,98 @@ interface CornerGuideProps {
   position: "top-left" | "top-right" | "bottom-left" | "bottom-right";
 }
 
+type DetectedCode = {
+  rawValue?: string;
+};
+
+type BarcodeDetectorInstance = {
+  detect: (source: ImageBitmapSource) => Promise<DetectedCode[]>;
+};
+
+type BarcodeDetectorConstructor = new (options?: {
+  formats?: string[];
+}) => BarcodeDetectorInstance;
+
 const SCAN_BOX_SIZE = 260;
 
 export default function QRStampModal({
   open,
   onClose,
-  onSubmit,
+  onSuccess,
 }: QRStampModalProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const isProcessingRef = useRef(false);
+
   const [cameraError, setCameraError] = useState("");
+
+  const checkQrMutation = useCheckQrMutation();
+
+  const stopCamera = () => {
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+  };
+
+  const parseQrValue = (rawValue: string) => {
+    try {
+      const url = new URL(rawValue);
+      const token = url.searchParams.get("token");
+      const memberId = url.searchParams.get("memberId");
+
+      if (!token || !memberId) return null;
+
+      return {
+        token,
+        memberId: Number(memberId),
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  const handleDetectedQr = async (rawValue: string) => {
+    if (isProcessingRef.current) return;
+
+    const parsedQr = parseQrValue(rawValue);
+
+    if (!parsedQr) {
+      setCameraError("올바르지 않은 QR입니다.");
+      return;
+    }
+
+    try {
+      isProcessingRef.current = true;
+
+      const response = await checkQrMutation.mutateAsync({
+        token: parsedQr.token,
+        memberId: parsedQr.memberId,
+      });
+
+      stopCamera();
+      onSuccess(response.data);
+    } catch {
+      setCameraError("QR 확인에 실패했습니다.");
+      isProcessingRef.current = false;
+    }
+  };
 
   useEffect(() => {
     if (!open) return;
 
+    let cancelled = false;
+
     const startCamera = async () => {
       try {
         setCameraError("");
+        isProcessingRef.current = false;
 
         const stream = await navigator.mediaDevices.getUserMedia({
           video: {
@@ -39,12 +116,57 @@ export default function QRStampModal({
           audio: false,
         });
 
+        if (cancelled) return;
+
         streamRef.current = stream;
 
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
           await videoRef.current.play();
         }
+
+        const BarcodeDetectorClass = (
+          window as Window & {
+            BarcodeDetector?: BarcodeDetectorConstructor;
+          }
+        ).BarcodeDetector;
+
+        if (!BarcodeDetectorClass) {
+          setCameraError("이 브라우저에서는 QR 스캔이 지원되지 않습니다.");
+          return;
+        }
+
+        const detector = new BarcodeDetectorClass({
+          formats: ["qr_code"],
+        });
+
+        const scan = async () => {
+          if (
+            cancelled ||
+            !videoRef.current ||
+            videoRef.current.readyState < 2 ||
+            isProcessingRef.current
+          ) {
+            frameRef.current = requestAnimationFrame(scan);
+            return;
+          }
+
+          try {
+            const results = await detector.detect(videoRef.current);
+            const qrValue = results[0]?.rawValue?.trim();
+
+            if (qrValue) {
+              await handleDetectedQr(qrValue);
+              return;
+            }
+          } catch {
+            // 프레임 단위 스캔 실패는 무시
+          }
+
+          frameRef.current = requestAnimationFrame(scan);
+        };
+
+        frameRef.current = requestAnimationFrame(scan);
       } catch {
         setCameraError("카메라에 접근할 수 없습니다.");
       }
@@ -53,17 +175,14 @@ export default function QRStampModal({
     startCamera();
 
     return () => {
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((track) => track.stop());
-        streamRef.current = null;
-      }
+      cancelled = true;
+      stopCamera();
     };
   }, [open]);
 
   useEffect(() => {
-    if (!open && streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => track.stop());
-      streamRef.current = null;
+    if (!open) {
+      stopCamera();
     }
   }, [open]);
 
@@ -97,7 +216,10 @@ export default function QRStampModal({
 
               <button
                 type="button"
-                onClick={onClose}
+                onClick={() => {
+                  stopCamera();
+                  onClose();
+                }}
                 className="absolute right-[1rem] top-[2.6rem] flex h-[2.8rem] w-[2.8rem] items-center justify-center"
                 aria-label="닫기"
               >
@@ -115,13 +237,11 @@ export default function QRStampModal({
               고객 QR을 스캔해주세요.
             </p>
 
-            <button
-              type="button"
-              onClick={onSubmit}
-              className="absolute bottom-[11rem] left-1/2 -translate-x-1/2 rounded-[999px] bg-primary-variant px-[4.8rem] py-[1.2rem] head3-m text-inverse"
-            >
-              적립하기
-            </button>
+            {checkQrMutation.isPending && (
+              <p className="mt-[1rem] body2-r text-primary-variant">
+                QR 확인 중...
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/apps/owner/src/shared/api/api.ts
+++ b/apps/owner/src/shared/api/api.ts
@@ -9,6 +9,7 @@ import {
   createStoreModule,
   createRandomBoxModule,
   createStoreImageModule,
+  createStoreManagerModule,
 } from "@compasser/api";
 
 const tokenStore: TokenStore = {
@@ -45,3 +46,4 @@ export const ownerModule = createOwnerModule(compasserApi);
 export const storeModule = createStoreModule(compasserApi);
 export const randomBoxModule = createRandomBoxModule(compasserApi);
 export const storeImageModule = createStoreImageModule(compasserApi);
+export const storeManagerModule = createStoreManagerModule(compasserApi);

--- a/apps/owner/src/shared/queries/mutation/store-manager/useQrMutation.ts
+++ b/apps/owner/src/shared/queries/mutation/store-manager/useQrMutation.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { storeManagerModule } from "@/shared/api/api";
+
+export const useCheckQrMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation(storeManagerModule.mutations.checkingQr(queryClient));
+};
+
+export const useWritingRewardMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation(storeManagerModule.mutations.writingReward(queryClient));
+};

--- a/packages/api/src/domains/store-manager.ts
+++ b/packages/api/src/domains/store-manager.ts
@@ -22,13 +22,18 @@ export const createStoreManagerModule = (api: CompasserApi) => {
       return data;
     },
 
-    checkingQr: async (body: QRDTO) => {
-      const { data } = await api.privateClient.get<GetMemberRewardResponse>(
+    checkingQr: async ({ token, memberId }: QRDTO) => {
+      const { data } = await api.privateClient.post<GetMemberRewardResponse>(
         "/store_manager/qr-check",
+        null,
         {
-          data: body,
+          params: {
+            token,
+            memberId,
+          },
         },
       );
+
       return data;
     },
   };

--- a/packages/api/src/models/member.ts
+++ b/packages/api/src/models/member.ts
@@ -17,8 +17,8 @@ export interface MyPageRespDTO {
 }
 
 export interface QRDTO {
-  memberId?: number;
-  token?: string;
+  token: string;
+  memberId: number;
 }
 
 export interface GetMemberRewardDTO {
@@ -26,9 +26,11 @@ export interface GetMemberRewardDTO {
   storeId: number;
   memberId: number;
   nickname: string;
+  email: string;
+  randomBoxName: string;
+  totalPrice: number;
   stamp: number;
   coupon: number;
-  createdAt: string;
 }
 
 export interface WritingRewardDTO {


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
> 사장님 앱에서 고객 QR을 스캔해 적립 대상 정보를 조회하고, 적립을 확정할 수 있는 QR 적립 플로우를 구현했습니다.

> 작업한 내용을 체크해주세요.
- [x] QR 스캔 모달 구현
- [x] QR URL에서 `token`, `memberId` 파싱 처리
- [x] `/store_manager/qr-check` API 연동 방식 수정
- [x] QR 조회 성공 시 고객 적립 정보 확인 모달 표시
- [x] `/store_manager/reward` API 연동을 통한 적립 처리
- [x] 적립 완료 후 관련 캐시 무효화 처리

## 🚀 설계 의도 및 개선점
> 구조 변경 이유 + 고민 + 해결 과정

- 서버 스펙 변경에 맞춰 QR 조회 API를 body 전송 방식에서 query parameter 전송 방식으로 수정했습니다.
- QR 스캔, 적립 정보 확인, 최종 적립 요청 흐름을 단계별 모달 구조로 분리해 사용자 흐름을 명확하게 구성했습니다.
- 적립 성공 후 마이페이지 및 리워드 관련 데이터를 최신 상태로 유지하기 위해 관련 query cache를 invalidate하도록 처리했습니다.

### 📸 스크린샷 (선택)
- QR 스캔 모달
- 적립 대상 확인 모달
- 적립 완료 동작 영상 첨부 예정

### 📎 기타 참고사항
- QR 값은 URL 형태로 전달되며, URL query에서 `token`, `memberId`를 추출해 사용합니다.
- `/store_manager/qr-check`는 query parameter 방식으로 호출합니다.
- `/store_manager/reward`는 request body 방식으로 호출합니다.
- 별도 환경 변수 변경은 없습니다.

Fixes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * QR 코드 자동 감지 기능으로 수동 스캔 단계 제거
  * 보상 적립 2단계 확인 플로우 추가
  * 적립 진행 상태 실시간 표시
  * 적립 전 사용자 정보 및 보상 세부사항 확인 모달 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->