### PR TITLE
[Feat/#88] 사장님 메인화면 API 연동

### DIFF
--- a/apps/owner/src/app/(tabs)/main/page.tsx
+++ b/apps/owner/src/app/(tabs)/main/page.tsx
@@ -3,22 +3,47 @@
 import CafeIntro from "./_components/CafeIntro";
 import TodayOrders from "./_components/TodayOrders";
 import TodayRewards from "./_components/TodayRewards";
-import {
-  MOCK_CAFE_NAME,
-  MOCK_ORDERS,
-  MOCK_REWARD_SUMMARY,
-} from "./_constants/mock";
+import { useSettlementPreviewQuery } from "@/shared/queries/query/useSettlementPreviewQuery";
 
 export default function OwnerMainPage() {
+  const { data: settlementPreview, isLoading, isError } =
+    useSettlementPreviewQuery();
+
+  const orders =
+    settlementPreview?.reservations.map((reservation) => ({
+      id: reservation.reservationId,
+      customerName: `회원 ${reservation.memberId}`,
+      randomBoxName: `예약 #${reservation.reservationId}`,
+      price: reservation.totalPrice,
+    })) ?? [];
+
+  if (isLoading) {
+    return (
+      <main className="bg-background min-h-full px-[1.6rem] pt-[5.6rem]">
+        <p className="text-body2 text-gray-600">정산 정보를 불러오는 중입니다.</p>
+      </main>
+    );
+  }
+
+  if (isError || !settlementPreview) {
+    return (
+      <main className="bg-background min-h-full px-[1.6rem] pt-[5.6rem]">
+        <p className="text-body2 text-gray-600">
+          정산 정보를 불러오지 못했습니다.
+        </p>
+      </main>
+    );
+  }
+
   return (
     <main className="bg-background min-h-full px-[1.6rem] pt-[5.6rem]">
-      <CafeIntro cafeName={MOCK_CAFE_NAME} />
+      <CafeIntro cafeName={settlementPreview.storeName} />
 
-      <TodayOrders orders={MOCK_ORDERS} />
+      <TodayOrders orders={orders} />
 
       <TodayRewards
-        couponUsedCount={MOCK_REWARD_SUMMARY.couponUsedCount}
-        stampSavedCount={MOCK_REWARD_SUMMARY.stampSavedCount}
+        couponUsedCount={settlementPreview.count}
+        stampSavedCount={settlementPreview.totalAmount}
       />
     </main>
   );

--- a/apps/owner/src/shared/queries/query/useSettlementPreviewQuery.ts
+++ b/apps/owner/src/shared/queries/query/useSettlementPreviewQuery.ts
@@ -1,0 +1,8 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { ownerModule } from "@/shared/api/api";
+
+export const useSettlementPreviewQuery = () => {
+  return useQuery(ownerModule.queries.settlementPreview());
+};

--- a/packages/api/src/domains/owner.ts
+++ b/packages/api/src/domains/owner.ts
@@ -8,6 +8,7 @@ import type {
   ReservationListResponse,
   ReservationReqDTO,
   ReservationResponse,
+  SettlementPreviewDTO,
 } from "../models/owner";
 
 export interface ReservationDecisionParams {
@@ -22,6 +23,8 @@ export const createOwnerModule = (api: CompasserApi) => {
     reservations: () => [...keys.all, "reservations"] as const,
     pendingReservations: () => [...keys.reservations(), "pending"] as const,
     processedReservations: () => [...keys.reservations(), "processed"] as const,
+    settlements: () => [...keys.all, "settlements"] as const,
+    settlementPreview: () => [...keys.settlements(), "preview"] as const,
   };
 
   const requests = {
@@ -71,6 +74,13 @@ export const createOwnerModule = (api: CompasserApi) => {
       );
       return data;
     },
+
+    getSettlementPreview: async (): Promise<SettlementPreviewDTO> => {
+      const { data } = await api.privateClient.get(
+        "/owners/my-store/settlements/preview",
+      );
+      return data;
+    },
   };
 
   const queries = {
@@ -84,6 +94,12 @@ export const createOwnerModule = (api: CompasserApi) => {
       queryOptions({
         queryKey: keys.processedReservations(),
         queryFn: async () => (await requests.getProcessedReservations()).data,
+      }),
+
+    settlementPreview: () =>
+      queryOptions({
+        queryKey: keys.settlementPreview(),
+        queryFn: async () => (await requests.getSettlementPreview()),
       }),
   };
 

--- a/packages/api/src/models/owner.ts
+++ b/packages/api/src/models/owner.ts
@@ -39,5 +39,20 @@ export interface ReservationListDTO {
   count: number;
 }
 
+export interface SettlementPreviewReservationDTO {
+  reservationId: number;
+  memberId: number;
+  totalPrice: number;
+  createdAt: string;
+}
+
+export interface SettlementPreviewDTO {
+  storeId: number;
+  storeName: string;
+  count: number;
+  totalAmount: number;
+  reservations: SettlementPreviewReservationDTO[];
+}
+
 export type ReservationResponse = ApiResponse<ReservationDTO>;
 export type ReservationListResponse = ApiResponse<ReservationListDTO>;


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
- Owner 정산 미리보기 API(`/owners/my-store/settlements/preview`) 연동
- ownerModule에 settlementPreview query 추가
- OwnerMainPage에서 목데이터 제거 후 API 데이터로 교체

> 작업한 내용을 체크해주세요.
- [x] settlementPreview API 요청 함수 추가
- [x] React Query queryOptions 연동
- [x] OwnerMainPage에 데이터 바인딩
- [x] 기존 mock 데이터 제거

## 🚀 설계 의도 및 개선점
- 기존 ownerModule 패턴(queryOptions 기반)을 유지하여 일관성 확보
- API 응답을 바로 사용할 수 있도록 request 단계에서 데이터 구조 단순화
- mock → 실제 API 전환으로 실제 데이터 기반 UI 동작 가능하도록 개선

### 📎 기타 참고사항
- interceptor에서 response.data를 unwrap하는 구조이므로 `data.data` 사용하지 않음

Fixes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **실시간 정산 미리보기** - 대시보드에서 매장의 예약 및 주문 현황, 주문 건수, 총액 등 정산 정보를 실시간으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->