### PR TITLE
[Feat/#98] 사용자 랜덤박스 구매 API 연동

### DIFF
--- a/apps/customer/next-env.d.ts
+++ b/apps/customer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/customer/src/app/(tabs)/main/store/[id]/purchase/_components/PurchaseContent.tsx
+++ b/apps/customer/src/app/(tabs)/main/store/[id]/purchase/_components/PurchaseContent.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Header } from "@compasser/design-system";
 import type {
-  JsonValue,
   StoreRandomBoxRespDTO,
   StoreRespDTO,
 } from "@compasser/api";
@@ -14,12 +13,17 @@ import PurchaseGuideModal from "./PurchaseGuideModal";
 import PurchaseNoticeCard from "./PurchaseNoticeCard";
 import PurchaseOrderCard from "./PurchaseOrderCard";
 
-type DayKey = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
-type BusinessHoursValue = Partial<Record<DayKey, string>>;
-
 interface PurchaseContentProps {
   store: StoreRespDTO;
   menu: StoreRandomBoxRespDTO;
+}
+
+interface PickupTimeValue {
+  timezone?: string;
+  pickupTime?: {
+    start?: string;
+    end?: string;
+  };
 }
 
 const NOTICE_LIST = [
@@ -28,55 +32,25 @@ const NOTICE_LIST = [
   "픽업 시간에 맞춰 상품을 수령해주세요.",
 ];
 
-const DAY_KEYS: DayKey[] = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-const DAY_LABELS: Record<DayKey, string> = {
-  mon: "월",
-  tue: "화",
-  wed: "수",
-  thu: "목",
-  fri: "금",
-  sat: "토",
-  sun: "일",
-};
-
-function parseBusinessHours(value?: JsonValue): BusinessHoursValue | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
+function getPickupTimeText(pickupTime?: string): string {
+  if (!pickupTime) {
+    return "픽업시간 정보 없음";
   }
 
-  const record = value as Record<string, unknown>;
-  const result: BusinessHoursValue = {};
+  try {
+    const parsed = JSON.parse(pickupTime) as PickupTimeValue;
 
-  const keys: DayKey[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+    const start = parsed.pickupTime?.start;
+    const end = parsed.pickupTime?.end;
 
-  for (const key of keys) {
-    const item = record[key];
-
-    if (typeof item === "string") {
-      result[key] = item;
+    if (!start || !end) {
+      return "픽업시간 정보 없음";
     }
+
+    return `${start} ~ ${end}`;
+  } catch {
+    return "픽업시간 정보 없음";
   }
-
-  return result;
-}
-
-function getTodayPickupTimeText(businessHours?: BusinessHoursValue): string {
-  if (!businessHours) {
-    return "운영시간 정보 없음";
-  }
-
-  const today = DAY_KEYS[new Date().getDay()];
-  const todayValue = businessHours[today];
-
-  if (!todayValue) {
-    return "운영시간 정보 없음";
-  }
-
-  if (todayValue.toLowerCase() === "closed") {
-    return `${DAY_LABELS[today]} 휴무`;
-  }
-
-  return `${DAY_LABELS[today]} ${todayValue}`;
 }
 
 export default function PurchaseContent({
@@ -96,9 +70,8 @@ export default function PurchaseContent({
   const totalPrice = useMemo(() => menu.price * count, [menu.price, count]);
 
   const pickupTimeText = useMemo(() => {
-    const businessHours = parseBusinessHours(store.businessHours);
-    return getTodayPickupTimeText(businessHours);
-  }, [store.businessHours]);
+    return getPickupTimeText(menu.pickupTimeInfo);
+  }, [menu.pickupTimeInfo]);
 
   const handleDecrease = () => {
     setCount((prev) => Math.max(prev - 1, 0));

--- a/apps/customer/src/app/(tabs)/main/store/[id]/purchase/_components/PurchaseContent.tsx
+++ b/apps/customer/src/app/(tabs)/main/store/[id]/purchase/_components/PurchaseContent.tsx
@@ -3,12 +3,16 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Header } from "@compasser/design-system";
-import type { JsonValue, StoreRespDTO, StoreRandomBoxRespDTO } from "@compasser/api";
+import type {
+  JsonValue,
+  StoreRandomBoxRespDTO,
+  StoreRespDTO,
+} from "@compasser/api";
+import { useCreateOrderMutation } from "@/shared/queries/mutation/order/useCreateOrderMutation";
+import { useReadyKakaoPayMutation } from "@/shared/queries/mutation/payment/useReadyKakaoPayMutation";
 import PurchaseGuideModal from "./PurchaseGuideModal";
-import PurchaseInfoSection from "./PurchaseInfoSection";
 import PurchaseNoticeCard from "./PurchaseNoticeCard";
 import PurchaseOrderCard from "./PurchaseOrderCard";
-import PurchaseCompleteModal from "./PurchaseCompleteModal";
 
 type DayKey = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 type BusinessHoursValue = Partial<Record<DayKey, string>>;
@@ -18,15 +22,9 @@ interface PurchaseContentProps {
   menu: StoreRandomBoxRespDTO;
 }
 
-const ACCOUNT_INFO = {
-  bankName: "나무은행",
-  accountNumber: "123-4567-891011",
-  depositor: "000",
-};
-
 const NOTICE_LIST = [
-  "결제 정보를 확인하고 이체를 진행해주세요.",
-  "10분 이내로 입금을 완료해주세요.",
+  "결제 정보를 확인하고 결제를 진행해주세요.",
+  "결제 완료 후 주문이 확정됩니다.",
   "픽업 시간에 맞춰 상품을 수령해주세요.",
 ];
 
@@ -53,6 +51,7 @@ function parseBusinessHours(value?: JsonValue): BusinessHoursValue | undefined {
 
   for (const key of keys) {
     const item = record[key];
+
     if (typeof item === "string") {
       result[key] = item;
     }
@@ -87,7 +86,12 @@ export default function PurchaseContent({
   const router = useRouter();
   const [count, setCount] = useState(1);
   const [isGuideModalOpen, setIsGuideModalOpen] = useState(false);
-  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
+
+  const createOrderMutation = useCreateOrderMutation();
+  const readyKakaoPayMutation = useReadyKakaoPayMutation();
+
+  const isPaymentPending =
+    createOrderMutation.isPending || readyKakaoPayMutation.isPending;
 
   const totalPrice = useMemo(() => menu.price * count, [menu.price, count]);
 
@@ -105,21 +109,39 @@ export default function PurchaseContent({
   };
 
   const handleOpenGuideModal = () => {
-    if (count === 0) return;
+    if (count === 0 || isPaymentPending) return;
     setIsGuideModalOpen(true);
   };
 
   const handleCloseGuideModal = () => {
+    if (isPaymentPending) return;
     setIsGuideModalOpen(false);
   };
 
-  const handleCompleteTransfer = () => {
-    setIsGuideModalOpen(false);
-    setIsCompleteModalOpen(true);
-  };
+  const handleCompleteTransfer = async () => {
+    if (count === 0 || isPaymentPending) return;
 
-  const handleCloseCompleteModal = () => {
-    setIsCompleteModalOpen(false);
+    const orderResponse = await createOrderMutation.mutateAsync({
+      randomBoxId: menu.boxId,
+      quantity: count,
+    });
+
+    const reservationId = orderResponse.data.reservationId;
+
+    sessionStorage.setItem(
+      "pendingPayment",
+      JSON.stringify({
+        reservationId,
+        store,
+        menu,
+        pickupTimeText,
+      }),
+    );
+
+    const readyResponse =
+      await readyKakaoPayMutation.mutateAsync(reservationId);
+
+    window.location.href = readyResponse.data.redirectUrl;
   };
 
   return (
@@ -143,19 +165,12 @@ export default function PurchaseContent({
               onIncrease={handleIncrease}
             />
 
-            <PurchaseInfoSection
-              bankName={ACCOUNT_INFO.bankName}
-              accountNumber={ACCOUNT_INFO.accountNumber}
-              depositor={ACCOUNT_INFO.depositor}
-              totalPrice={totalPrice}
-            />
-
             <PurchaseNoticeCard noticeList={NOTICE_LIST} />
 
             <Button
               size="lg"
               variant="primary"
-              disabled={count === 0}
+              disabled={count === 0 || isPaymentPending}
               className="mb-[4.8rem] mt-[1.6rem]"
               onClick={handleOpenGuideModal}
             >
@@ -167,17 +182,9 @@ export default function PurchaseContent({
 
       <PurchaseGuideModal
         isOpen={isGuideModalOpen}
-        accountText={`${ACCOUNT_INFO.bankName}${ACCOUNT_INFO.accountNumber}`}
+        accountText={`${totalPrice.toLocaleString()}원`}
         onClose={handleCloseGuideModal}
         onConfirm={handleCompleteTransfer}
-      />
-
-      <PurchaseCompleteModal
-        isOpen={isCompleteModalOpen}
-        store={store}
-        menu={menu}
-        pickupTimeText={pickupTimeText}
-        onClose={handleCloseCompleteModal}
       />
     </>
   );

--- a/apps/customer/src/app/payment/cancel/page.tsx
+++ b/apps/customer/src/app/payment/cancel/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCancelKakaoPayMutation } from "@/shared/queries/mutation/payment/useCancelKakaoPayMutation";
+
+export default function PaymentCancelPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const cancelKakaoPayMutation = useCancelKakaoPayMutation();
+
+  useEffect(() => {
+    const reservationId = Number(searchParams.get("reservationId"));
+
+    if (!reservationId) return;
+
+    cancelKakaoPayMutation.mutate(reservationId, {
+      onSettled: () => {
+        sessionStorage.removeItem("pendingPayment");
+        router.replace("/main");
+      },
+    });
+  }, [searchParams]);
+
+  return <div>결제가 취소되었습니다.</div>;
+}

--- a/apps/customer/src/app/payment/cancel/page.tsx
+++ b/apps/customer/src/app/payment/cancel/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCancelKakaoPayMutation } from "@/shared/queries/mutation/payment/useCancelKakaoPayMutation";
 
-export default function PaymentCancelPage() {
+function PaymentCancelContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const cancelKakaoPayMutation = useCancelKakaoPayMutation();
@@ -20,7 +20,15 @@ export default function PaymentCancelPage() {
         router.replace("/main");
       },
     });
-  }, [searchParams]);
+  }, [searchParams, cancelKakaoPayMutation, router]);
 
   return <div>결제가 취소되었습니다.</div>;
+}
+
+export default function PaymentCancelPage() {
+  return (
+    <Suspense fallback={<div>결제 취소 처리 중...</div>}>
+      <PaymentCancelContent />
+    </Suspense>
+  );
 }

--- a/apps/customer/src/app/payment/success/page.tsx
+++ b/apps/customer/src/app/payment/success/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import type { StoreRespDTO, StoreRandomBoxRespDTO } from "@compasser/api";
+import type { StoreRandomBoxRespDTO, StoreRespDTO } from "@compasser/api";
 import { useApproveKakaoPayMutation } from "@/shared/queries/mutation/payment/useApproveKakaoPayMutation";
 import PurchaseCompleteModal from "@/app/(tabs)/main/store/[id]/purchase/_components/PurchaseCompleteModal";
 
@@ -13,7 +13,7 @@ interface PendingPayment {
   pickupTimeText: string;
 }
 
-export default function PaymentSuccessPage() {
+function PaymentSuccessContent() {
   const searchParams = useSearchParams();
   const approveKakaoPayMutation = useApproveKakaoPayMutation();
   const [pendingPayment, setPendingPayment] = useState<PendingPayment | null>(
@@ -49,7 +49,7 @@ export default function PaymentSuccessPage() {
         },
       },
     );
-  }, [reservationId, pgToken]);
+  }, [reservationId, pgToken, approveKakaoPayMutation]);
 
   if (approveKakaoPayMutation.isPending) {
     return <div>결제 승인 처리 중...</div>;
@@ -70,5 +70,13 @@ export default function PaymentSuccessPage() {
       menu={pendingPayment.menu}
       pickupTimeText={pendingPayment.pickupTimeText}
     />
+  );
+}
+
+export default function PaymentSuccessPage() {
+  return (
+    <Suspense fallback={<div>결제 승인 처리 중...</div>}>
+      <PaymentSuccessContent />
+    </Suspense>
   );
 }

--- a/apps/customer/src/app/payment/success/page.tsx
+++ b/apps/customer/src/app/payment/success/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import type { StoreRespDTO, StoreRandomBoxRespDTO } from "@compasser/api";
+import { useApproveKakaoPayMutation } from "@/shared/queries/mutation/payment/useApproveKakaoPayMutation";
+import PurchaseCompleteModal from "@/app/(tabs)/main/store/[id]/purchase/_components/PurchaseCompleteModal";
+
+interface PendingPayment {
+  reservationId: number;
+  store: StoreRespDTO;
+  menu: StoreRandomBoxRespDTO;
+  pickupTimeText: string;
+}
+
+export default function PaymentSuccessPage() {
+  const searchParams = useSearchParams();
+  const approveKakaoPayMutation = useApproveKakaoPayMutation();
+  const [pendingPayment, setPendingPayment] = useState<PendingPayment | null>(
+    null,
+  );
+  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
+
+  const reservationId = useMemo(
+    () => Number(searchParams.get("reservationId")),
+    [searchParams],
+  );
+
+  const pgToken = searchParams.get("pg_token");
+
+  useEffect(() => {
+    const savedPayment = sessionStorage.getItem("pendingPayment");
+
+    if (!savedPayment || !reservationId || !pgToken) return;
+
+    const parsedPayment = JSON.parse(savedPayment) as PendingPayment;
+
+    setPendingPayment(parsedPayment);
+
+    approveKakaoPayMutation.mutate(
+      {
+        reservationId,
+        pg_token: pgToken,
+      },
+      {
+        onSuccess: () => {
+          sessionStorage.removeItem("pendingPayment");
+          setIsCompleteModalOpen(true);
+        },
+      },
+    );
+  }, [reservationId, pgToken]);
+
+  if (approveKakaoPayMutation.isPending) {
+    return <div>결제 승인 처리 중...</div>;
+  }
+
+  if (approveKakaoPayMutation.isError) {
+    return <div>결제 승인에 실패했습니다.</div>;
+  }
+
+  if (!pendingPayment) {
+    return <div>결제 정보를 불러오는 중입니다.</div>;
+  }
+
+  return (
+    <PurchaseCompleteModal
+      isOpen={isCompleteModalOpen}
+      store={pendingPayment.store}
+      menu={pendingPayment.menu}
+      pickupTimeText={pendingPayment.pickupTimeText}
+    />
+  );
+}

--- a/apps/customer/src/shared/api/api.ts
+++ b/apps/customer/src/shared/api/api.ts
@@ -8,6 +8,7 @@ import {
   type TokenStore,
   createMemberModule,
   createOrderModule,
+  createPaymentModule,
 } from "@compasser/api";
 
 const tokenStore: TokenStore = {
@@ -43,3 +44,4 @@ export const authModule = createAuthModule(compasserApi);
 export const memberModule = createMemberModule(compasserApi);
 export const storeModule = createStoreModule(compasserApi);
 export const orderModule = createOrderModule(compasserApi);
+export const paymentModule = createPaymentModule(compasserApi);

--- a/apps/customer/src/shared/queries/mutation/order/useCancelOrderMutation.ts
+++ b/apps/customer/src/shared/queries/mutation/order/useCancelOrderMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import { orderModule } from "@/shared/api/api";
+
+export const useCancelOrderMutation = () => {
+  return useMutation({
+    mutationFn: (orderId: number) =>
+      orderModule.requests.cancelOrder(orderId),
+  });
+};

--- a/apps/customer/src/shared/queries/mutation/order/useCreateOrderMutation.ts
+++ b/apps/customer/src/shared/queries/mutation/order/useCreateOrderMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import type { CreateOrderDTO } from "@compasser/api";
+import { orderModule } from "@/shared/api/api";
+
+export const useCreateOrderMutation = () => {
+  return useMutation({
+    mutationFn: (body: CreateOrderDTO) =>
+      orderModule.requests.createOrder(body),
+  });
+};

--- a/apps/customer/src/shared/queries/mutation/payment/useApproveKakaoPayMutation.ts
+++ b/apps/customer/src/shared/queries/mutation/payment/useApproveKakaoPayMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { paymentModule } from "@/shared/api/api";
+
+interface ApproveKakaoPayParams {
+  reservationId: number;
+  pg_token: string;
+}
+
+export const useApproveKakaoPayMutation = () => {
+  return useMutation({
+    mutationFn: ({ reservationId, pg_token }: ApproveKakaoPayParams) =>
+      paymentModule.requests.approveKakaoPay({
+        reservationId,
+        pg_token,
+      }),
+  });
+};

--- a/apps/customer/src/shared/queries/mutation/payment/useCancelKakaoPayMutation.ts
+++ b/apps/customer/src/shared/queries/mutation/payment/useCancelKakaoPayMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import { paymentModule } from "@/shared/api/api";
+
+export const useCancelKakaoPayMutation = () => {
+  return useMutation({
+    mutationFn: (reservationId: number) =>
+      paymentModule.requests.cancelKakaoPay({ reservationId }),
+  });
+};

--- a/apps/customer/src/shared/queries/mutation/payment/useReadyKakaoPayMutation.ts
+++ b/apps/customer/src/shared/queries/mutation/payment/useReadyKakaoPayMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import { paymentModule } from "@/shared/api/api";
+
+export const useReadyKakaoPayMutation = () => {
+  return useMutation({
+    mutationFn: (reservationId: number) =>
+      paymentModule.requests.readyKakaoPay({ reservationId }),
+  });
+};

--- a/packages/api/src/models/order.ts
+++ b/packages/api/src/models/order.ts
@@ -17,15 +17,8 @@ export interface CreateOrderResultDTO {
   quantity: number;
   unitPrice: number;
   totalPrice: number;
-  orderStatus: string;
   reservationStatus: string;
   paymentStatus: string;
-  pickupStatus: string;
-  memberBankType?: BankType;
-  depositBankType?: BankType;
-  depositAccountNumber?: string;
-  depositAccountHolder?: string;
-  businessHours?: string;
   createdAt: string;
 }
 
@@ -34,7 +27,6 @@ export interface CancelOrderResultDTO {
   orderStatus: string;
   reservationStatus: string;
   paymentStatus: string;
-  pickupStatus: string;
   message: string;
 }
 

--- a/packages/api/src/models/payment.ts
+++ b/packages/api/src/models/payment.ts
@@ -1,19 +1,19 @@
 import type { ApiResponse } from "../core/types";
 
-export interface ReadyResultDTO {
+export interface ReadyKakaoPayResultDTO {
   reservationId: number;
   tid: string;
   redirectUrl: string;
   paymentStatus: string;
 }
 
-export interface ApproveResultDTO {
+export interface ApproveKakaoPayResultDTO {
   reservationId: number;
   paymentMethod: string;
   paymentStatus: string;
   approvedAt: string;
 }
 
-export type ReadyKakaoPayResponse = ApiResponse<ReadyResultDTO>;
-export type CancelKakaoPayResponse = ApiResponse<Record<string, unknown>>;
-export type ApproveKakaoPayResponse = ApiResponse<ApproveResultDTO>;
+export type ReadyKakaoPayResponse = ApiResponse<ReadyKakaoPayResultDTO>;
+export type CancelKakaoPayResponse = ApiResponse<Record<string, never>>;
+export type ApproveKakaoPayResponse = ApiResponse<ApproveKakaoPayResultDTO>;

--- a/packages/api/src/models/store.ts
+++ b/packages/api/src/models/store.ts
@@ -18,6 +18,7 @@ export interface StoreImageDTO {
   id: number;
   imageUrl: string;
   createdAt?: string;
+  store?: unknown;
 }
 
 export interface StoreRandomBoxRespDTO {
@@ -29,6 +30,7 @@ export interface StoreRandomBoxRespDTO {
   buyLimit: number;
   content: string;
   saleStatus: string;
+  pickupTimeInfo?: string;
 }
 
 export interface StoreRespDTO {
@@ -66,7 +68,6 @@ export interface SimpleStoreInfoDTO {
   storeName: string;
   roadAddress: string;
   jibunAddress: string;
-  storeEmail: string;
   businessHours?: JsonValue;
 }
 


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
> 카카오페이 결제 흐름(API 5종) 연동 및 기존 목데이터 제거

- 구매 페이지에서 **주문 생성 → 카카오페이 결제 준비** API 연동
- 카카오페이 redirect 기반 결제 구조로 전환
- 결제 성공/취소 페이지 분리 (`/payment/success`, `/payment/cancel`)
- React Query mutation 기반 API 호출 구조 적용
- 기존 계좌이체 UI 및 목데이터 제거 → 카카오페이 기준으로 변경

> 작업한 내용을 체크해주세요.
- [x] 주문 생성 API 연동 (POST /orders)
- [x] 카카오페이 ready API 연동
- [x] 카카오페이 approve API 연동 (success 페이지)
- [x] 카카오페이 cancel API 연동 (cancel 페이지)
- [x] 기존 목데이터 제거 (계좌 정보)
- [x] 결제 완료 모달 → redirect 기반 처리로 변경

## 🚀 설계 의도 및 개선점
> 구조 변경 이유 + 고민 + 해결 과정

- 기존에는 **모달 기반 가짜 결제 흐름**이었으나, 실제 카카오페이 연동을 위해 **redirect 기반 구조로 전환**
- 결제 과정이 외부 페이지를 거치기 때문에:
  - `PurchaseContent` → 주문 생성 + ready까지만 담당
  - `success/cancel 페이지` → 후속 처리 (approve / cancel)
  👉 **책임 분리 구조로 설계**

- 결제 완료 데이터 유지 문제 해결:
  - `sessionStorage`를 활용하여 결제 전 상태(store, menu 등) 저장
  - success 페이지에서 복원 후 완료 UI 렌더링

- React Query mutation으로 통일하여:
  - API 호출 흐름 명확화
  - 로딩/에러 상태 관리 가능하도록 개선

### 📸 스크린샷 (선택)
- 결제하기 클릭 → 카카오페이 페이지 이동
- 결제 완료 후 success 페이지 → 완료 UI 표시

### 📎 기타 참고사항
- 카카오페이 redirect URL:
  - `/payment/success`
  - `/payment/cancel`
- 테스트 방식:
  - 실제 redirectUrl로 이동 → pg_token 확인 → approve 정상 동작 확인
- `cancelOrder` API는 현재 사용하지 않으며, 추후 주문내역 페이지에서 사용 예정

Fixes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * KakaoPay 결제 흐름 도입(주문 생성 → 결제 준비 → 리디렉션)
  * 결제 성공 및 결제 취소 전용 페이지 추가
  * 주문 생성 및 주문 취소 기능 추가

* **개선 사항**
  * 구매 확인 흐름 재구성 및 결제 중 UI/작업 제한으로 안정성 강화
  * 픽업 시간 표기 방식 조정(메뉴 기반 정보 사용)
  * 구매 완료 관련 UI(계좌/입금 정보 및 완료 모달) 간소화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->