### PR TITLE
[Feat/#97] 카카오 로그인 API 연동

### DIFF
--- a/apps/customer/src/app/auth/callback/page.tsx
+++ b/apps/customer/src/app/auth/callback/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function KakaoCallbackContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const accessToken = searchParams.get("accessToken");
+    const refreshToken = searchParams.get("refreshToken");
+
+    if (accessToken) {
+      localStorage.setItem("accessToken", accessToken);
+    }
+
+    if (refreshToken) {
+      localStorage.setItem("refreshToken", refreshToken);
+    }
+
+    router.replace("/role-select");
+  }, [router, searchParams]);
+
+  return <div>카카오 로그인 처리 중...</div>;
+}
+
+export default function KakaoCallbackPage() {
+  return (
+    <Suspense fallback={<div>카카오 로그인 처리 중...</div>}>
+      <KakaoCallbackContent />
+    </Suspense>
+  );
+}

--- a/apps/customer/src/app/login/_components/KakaoLoginButton.tsx
+++ b/apps/customer/src/app/login/_components/KakaoLoginButton.tsx
@@ -3,17 +3,22 @@
 import { Icon } from "@compasser/design-system";
 import { LOGIN_TEXT } from "../_constants/login.constants";
 
-interface KakaoLoginButtonProps {
-  onClick: () => void;
-}
+export default function KakaoLoginButton() {
+  const handleKakaoLogin = () => {
+    const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export default function KakaoLoginButton({
-  onClick,
-}: KakaoLoginButtonProps) {
+    if (!baseURL) {
+      console.log("NEXT_PUBLIC_API_BASE_URL이 없습니다.");
+      return;
+    }
+
+    window.location.href = `${baseURL}/oauth2/authorization/kakao`;
+  };
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={handleKakaoLogin}
       aria-label={LOGIN_TEXT.kakaoLoginButton}
       className="relative flex w-full items-center justify-center rounded-[8px] bg-[#FEE500] px-[1.2rem] py-[1rem]"
     >

--- a/apps/customer/src/app/login/page.tsx
+++ b/apps/customer/src/app/login/page.tsx
@@ -67,10 +67,6 @@ export default function LoginPage() {
     );
   };
 
-  const handleKakaoLogin = () => {
-    console.log("카카오 로그인");
-  };
-
   return (
     <main className="flex min-h-screen w-full items-center justify-center px-[1.6rem]">
       <section className="w-full">
@@ -84,7 +80,7 @@ export default function LoginPage() {
           />
 
           <div className="mt-[1.2rem] w-full">
-            <KakaoLoginButton onClick={handleKakaoLogin} />
+            <KakaoLoginButton />
           </div>
 
           <SignupLinkButton onClick={handleMoveRoleSelect} />


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
> 카카오 로그인 버튼 및 OAuth 연동 흐름 구현

- 카카오 로그인 버튼 클릭 시 백엔드 OAuth 시작 URL로 redirect 처리
- `/auth/callback` 페이지 추가 및 accessToken 저장 로직 구현
- 로그인 완료 후 `/role-select`로 이동하도록 처리

> 작업한 내용을 체크해주세요.
- [x] 카카오 로그인 버튼 동작 구현
- [x] OAuth redirect 흐름 연결
- [x] callback 페이지 생성 및 토큰 저장
- [x] 로그인 후 페이지 이동 처리

## 🚀 설계 의도 및 개선점
> 구조 변경 이유 + 고민 + 해결 과정

- 카카오 OAuth 특성상 외부 페이지를 거치므로 redirect 기반 구조로 설계
- 로그인 버튼에서는 단순 URL 이동만 담당하고, 실제 로그인 완료 처리는 callback 페이지로 분리
- 토큰 저장 및 라우팅 로직을 callback 페이지로 집중시켜 책임 분리

### 📎 기타 참고사항
- `/oauth2/authorization/kakao` 경로 사용
- `/auth/callback`에서 accessToken query param 기반 처리
- 백엔드에서 프론트 callback으로 redirect 필요

Fixes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * Kakao 로그인 콜백 처리 추가
  * 로그인 후 역할 선택 페이지로의 자동 리다이렉션 구현

* **개선 사항**
  * Kakao 로그인 버튼의 로그인 흐름 간소화 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->