### PR TITLE
[Feat/#108] 사장님 예약/주문 API 연동

### DIFF
--- a/apps/owner/src/app/(tabs)/order/_components/modal/RejectOrderModal.tsx
+++ b/apps/owner/src/app/(tabs)/order/_components/modal/RejectOrderModal.tsx
@@ -16,11 +16,19 @@ export default function RejectOrderModal({
 }: RejectOrderModalProps) {
   const [reason, setReason] = useState("");
 
+  const trimmedReason = reason.trim();
+  const isValidReason = trimmedReason.length >= 10;
+
   useEffect(() => {
     if (!open) {
       setReason("");
     }
   }, [open]);
+
+  const handleConfirm = () => {
+    if (!isValidReason) return;
+    onConfirm(trimmedReason);
+  };
 
   return (
     <Modal
@@ -47,7 +55,8 @@ export default function RejectOrderModal({
             variant="primary"
             fullWidth={false}
             className="px-[2.2rem]"
-            onClick={() => onConfirm(reason)}
+            onClick={handleConfirm}
+            disabled={!isValidReason}
           >
             거절하기
           </Button>
@@ -58,7 +67,7 @@ export default function RejectOrderModal({
         <input
           value={reason}
           onChange={(e) => setReason(e.target.value)}
-          placeholder="거절 사유를 입력해주세요."
+          placeholder="거절 사유를 입력해주세요. (10자 이상)"
           className="
             w-full rounded-[8px] border border-primary
             px-[1rem] py-[0.6rem]
@@ -67,6 +76,12 @@ export default function RejectOrderModal({
             outline-none
           "
         />
+
+        {!isValidReason && reason.length > 0 && (
+          <p className="caption-m mt-[0.6rem] text-secondary">
+            거절 사유는 10자 이상 입력해주세요.
+          </p>
+        )}
       </div>
     </Modal>
   );

--- a/apps/owner/src/app/(tabs)/order/_types/order.ts
+++ b/apps/owner/src/app/(tabs)/order/_types/order.ts
@@ -1,6 +1,10 @@
 export type OrderTabKey = "reservation" | "order";
 
-export type ReservationStatus = "pending" | "completed" | "cancelled";
+export type ReservationStatus =
+  | "pending"
+  | "completed"
+  | "cancelled"
+  | "refunded";
 
 export interface ReservationItem {
   id: number;
@@ -10,6 +14,7 @@ export interface ReservationItem {
   quantity: string;
   status: ReservationStatus;
   processedAt?: string;
+  rejectReason?: string;
 }
 
 export interface AcceptModalState {

--- a/apps/owner/src/app/(tabs)/order/_utils/orderStatus.ts
+++ b/apps/owner/src/app/(tabs)/order/_utils/orderStatus.ts
@@ -2,26 +2,30 @@ import type { ReservationStatus } from "../_types/order";
 
 export const getStatusLabel = (status: ReservationStatus) => {
   switch (status) {
-  case "pending":
-    return "확인 대기중";
-  case "completed":
-    return "거래완료";
-  case "cancelled":
-    return "거래취소";
-  default:
-    return "";
+    case "pending":
+      return "확인 대기중";
+    case "completed":
+      return "거래완료";
+    case "cancelled":
+      return "거래취소";
+    case "refunded":
+      return "환불";
+    default:
+      return "";
   }
 };
 
 export const getStatusClassName = (status: ReservationStatus) => {
   switch (status) {
-  case "pending":
-    return "body1-m text-secondary";
-  case "completed":
-    return "body1-m text-primary";
-  case "cancelled":
-    return "body1-m text-gray-500";
-  default:
-    return "";
+    case "pending":
+      return "body1-m text-secondary";
+    case "completed":
+      return "body1-m text-primary";
+    case "cancelled":
+      return "body1-m text-gray-500";
+    case "refunded":
+      return "body1-m text-secondary";
+    default:
+      return "";
   }
 };

--- a/apps/owner/src/app/(tabs)/order/page.tsx
+++ b/apps/owner/src/app/(tabs)/order/page.tsx
@@ -5,20 +5,51 @@ import { Header, TopTabBar } from "@compasser/design-system";
 import OrderList from "./_components/OrderList";
 import AcceptOrderModal from "./_components/modal/AcceptOrderModal";
 import RejectOrderModal from "./_components/modal/RejectOrderModal";
-import { INITIAL_RESERVATIONS } from "./_constants/mockOrders";
-import { formatProcessedAt } from "./_utils/formatProcessAt";
 import type {
   AcceptModalState,
   OrderTabKey,
   RejectModalState,
   ReservationItem,
 } from "./_types/order";
+import { usePendingReservationsQuery } from "@/shared/queries/query/owner/usePendingReservationsQuery";
+import { useProcessedReservationsQuery } from "@/shared/queries/query/owner/useProcessedReservationsQuery";
+import { useApproveReservationMutation } from "@/shared/queries/mutation/owner/useApproveReservationMutation";
+import { useRejectReservationMutation } from "@/shared/queries/mutation/owner/useRejectReservationMutation";
+import type { ReservationDTO } from "@compasser/api";
+
+const formatPrice = (price: number) => `${price.toLocaleString()}원`;
+
+const mapReservationStatus = (
+  status: ReservationDTO["status"],
+): ReservationItem["status"] => {
+  switch (status) {
+    case "REQUESTED":
+      return "pending";
+    case "APPROVED":
+      return "completed";
+    case "REJECTED":
+      return "cancelled";
+    case "CANCELED":
+      return "refunded";
+    default:
+      return "pending";
+  }
+};
+
+const mapReservationToItem = (
+  reservation: ReservationDTO,
+): ReservationItem => ({
+  id: reservation.reservationId,
+  customerName: reservation.customerName,
+  orderDetail: reservation.randomBoxName,
+  price: formatPrice(reservation.totalPrice),
+  quantity: `${reservation.requestedQuantity}개`,
+  status: mapReservationStatus(reservation.status),
+  rejectReason: reservation.rejectReason,
+});
 
 export default function OrderStatusPage() {
   const [activeTab, setActiveTab] = useState<OrderTabKey>("reservation");
-  const [orders, setOrders] = useState<ReservationItem[]>(INITIAL_RESERVATIONS);
-  const isOrderTabKey = (key: string): key is OrderTabKey =>
-   key === "reservation" || key === "order";
 
   const [acceptModal, setAcceptModal] = useState<AcceptModalState>({
     isOpen: false,
@@ -30,18 +61,44 @@ export default function OrderStatusPage() {
     orderId: null,
   });
 
+  const {
+    data: pendingReservationData,
+    isLoading: isPendingLoading,
+    isError: isPendingError,
+  } = usePendingReservationsQuery();
+
+  const {
+    data: processedReservationData,
+    isLoading: isProcessedLoading,
+    isError: isProcessedError,
+  } = useProcessedReservationsQuery();
+
+  const approveMutation = useApproveReservationMutation();
+  const rejectMutation = useRejectReservationMutation();
+
+  const isOrderTabKey = (key: string): key is OrderTabKey =>
+    key === "reservation" || key === "order";
+
   const reservationOrders = useMemo(
-    () => orders.filter((order) => order.status === "pending"),
-    [orders]
+    () =>
+      pendingReservationData?.reservations.map(mapReservationToItem) ?? [],
+    [pendingReservationData],
   );
 
-  const completedOrders = useMemo(
-    () => orders.filter((order) => order.status !== "pending"),
-    [orders]
+  const processedOrders = useMemo(
+    () =>
+      processedReservationData?.reservations.map(mapReservationToItem) ?? [],
+    [processedReservationData],
   );
 
   const currentOrders =
-    activeTab === "reservation" ? reservationOrders : completedOrders;
+    activeTab === "reservation" ? reservationOrders : processedOrders;
+
+  const isLoading =
+    activeTab === "reservation" ? isPendingLoading : isProcessedLoading;
+
+  const isError =
+    activeTab === "reservation" ? isPendingError : isProcessedError;
 
   const openAcceptModal = (orderId: number) => {
     setAcceptModal({
@@ -74,41 +131,31 @@ export default function OrderStatusPage() {
   const handleAcceptOrder = () => {
     if (acceptModal.orderId === null) return;
 
-    const now = formatProcessedAt(new Date());
-
-    setOrders((prev) =>
-      prev.map((order) =>
-        order.id === acceptModal.orderId
-          ? {
-            ...order,
-            status: "completed",
-            processedAt: now,
-          }
-          : order
-      )
+    approveMutation.mutate(
+      {
+        reservationId: acceptModal.orderId,
+      },
+      {
+        onSuccess: closeAcceptModal,
+      },
     );
-
-    closeAcceptModal();
   };
 
-  const handleRejectOrder = (_reason: string) => {
+  const handleRejectOrder = (reason: string) => {
     if (rejectModal.orderId === null) return;
 
-    const now = formatProcessedAt(new Date());
-
-    setOrders((prev) =>
-      prev.map((order) =>
-        order.id === rejectModal.orderId
-          ? {
-            ...order,
-            status: "cancelled",
-            processedAt: now,
-          }
-          : order
-      )
+    rejectMutation.mutate(
+      {
+        reservationId: rejectModal.orderId,
+        body: {
+          status: "REQUESTED",
+          rejectReason: reason,
+        },
+      },
+      {
+        onSuccess: closeRejectModal,
+      },
     );
-
-    closeRejectModal();
   };
 
   return (
@@ -128,12 +175,24 @@ export default function OrderStatusPage() {
         />
 
         <section className="flex-1 overflow-y-auto px-[1.6rem] pt-[2.8rem] pb-[10rem]">
-          <OrderList
-            activeTab={activeTab}
-            orders={currentOrders}
-            onAccept={openAcceptModal}
-            onReject={openRejectModal}
-          />
+          {isLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <p className="body1-m text-gray-600">불러오는 중이에요.</p>
+            </div>
+          ) : isError ? (
+            <div className="flex h-full items-center justify-center">
+              <p className="body1-m text-gray-600">
+                주문 내역을 불러오지 못했어요.
+              </p>
+            </div>
+          ) : (
+            <OrderList
+              activeTab={activeTab}
+              orders={currentOrders}
+              onAccept={openAcceptModal}
+              onReject={openRejectModal}
+            />
+          )}
         </section>
       </main>
 

--- a/apps/owner/src/shared/queries/mutation/owner/useApproveReservationMutation.ts
+++ b/apps/owner/src/shared/queries/mutation/owner/useApproveReservationMutation.ts
@@ -1,0 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ownerModule } from "@/shared/api/api";
+
+export const useApproveReservationMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(ownerModule.mutations.approveReservation(queryClient));
+};

--- a/apps/owner/src/shared/queries/mutation/owner/useRejectReservationMutation.ts
+++ b/apps/owner/src/shared/queries/mutation/owner/useRejectReservationMutation.ts
@@ -1,0 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ownerModule } from "@/shared/api/api";
+
+export const useRejectReservationMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(ownerModule.mutations.rejectReservation(queryClient));
+};

--- a/apps/owner/src/shared/queries/query/owner/usePendingReservationsQuery.ts
+++ b/apps/owner/src/shared/queries/query/owner/usePendingReservationsQuery.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { ownerModule } from "@/shared/api/api";
+
+export const usePendingReservationsQuery = () => {
+  return useQuery(ownerModule.queries.pendingReservations());
+};

--- a/apps/owner/src/shared/queries/query/owner/useProcessedReservationsQuery.ts
+++ b/apps/owner/src/shared/queries/query/owner/useProcessedReservationsQuery.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { ownerModule } from "@/shared/api/api";
+
+export const useProcessedReservationsQuery = () => {
+  return useQuery(ownerModule.queries.processedReservations());
+};

--- a/packages/api/src/domains/owner.ts
+++ b/packages/api/src/domains/owner.ts
@@ -6,14 +6,14 @@ import type {
   BusinessLicenseVerifyReqDTO,
   OwnerUpgradeRespDTO,
   ReservationListResponse,
-  ReservationReqDTO,
+  ReservationRejectReqDTO,
   ReservationResponse,
   SettlementPreviewDTO,
 } from "../models/owner";
 
 export interface ReservationDecisionParams {
   reservationId: number;
-  body?: ReservationReqDTO;
+  body?: ReservationRejectReqDTO;
 }
 
 export const createOwnerModule = (api: CompasserApi) => {

--- a/packages/api/src/models/owner.ts
+++ b/packages/api/src/models/owner.ts
@@ -13,30 +13,27 @@ export interface OwnerUpgradeRespDTO {
   alreadyUpgraded: boolean;
 }
 
-export interface ReservationReqDTO {
+export interface ReservationRejectReqDTO {
   status?: ReservationStatus;
-  rejectReason?: string;
+  rejectReason: string;
 }
 
 export interface ReservationDTO {
   reservationId: number;
   memberId: number;
-  nickName: string;
+  customerName: string;
   storeId: number;
   storeName: string;
   randomBoxId: number;
   randomBoxName: string;
-  price: number;
+  totalPrice: number;
   status: ReservationStatus;
   requestedQuantity: number;
   rejectReason?: string;
-  createdAt: string;
-  updatedAt: string;
 }
 
 export interface ReservationListDTO {
   reservations: ReservationDTO[];
-  count: number;
 }
 
 export interface SettlementPreviewReservationDTO {


### PR DESCRIPTION
## ✅ 작업 내용

#### 📝 Description
- 점장 주문/예약 관리 API 연동
- 예약/주문 탭 데이터 서버 연동 및 목데이터 제거
- 예약 수락/거절 mutation 연동
- 주문 상태값(거래완료/거래취소/환불) UI 반영
- 거절 사유 입력 validation 추가 (10자 이상 필수)

> 작업한 내용을 체크해주세요.
- [x] 예약 목록 조회 API 연동
- [x] 처리 완료 목록 조회 API 연동
- [x] 예약 수락/거절 API 연동
- [x] 주문 상태 UI 반영
- [x] 거절 사유 validation 적용

## 🚀 설계 의도 및 개선점
- mock 데이터 기반 화면을 실제 서버 데이터 기반으로 전환
- query/mutation 파일을 역할별로 분리해 유지보수성 향상
- 주문 상태값을 util로 관리해 UI 재사용성 확보
- 거절 사유 validation을 추가해 잘못된 요청 방지

### 📸 스크린샷 (선택)
- 주문 현황 화면
- 예약 수락/거절 모달

### 📎 기타 참고사항
- TanStack Query 기반 query/mutation 적용
- owner token(localStorage) 기반 인증 테스트 완료

Fixes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 상태에 "환불" 상태 추가
  * 서버 기반 주문 데이터 실시간 동기화

* **버그 수정**
  * 주문 거절 사유 입력 검증 강화 (최소 10자 이상 필수)
  * 주문 거절 시 사유 정보 저장 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->