### PR TITLE
[Feat/#106] 사장님 가게 등록 관련 API 연동 

### DIFF
--- a/apps/owner/src/app/(tabs)/mypage/store-info/page.tsx
+++ b/apps/owner/src/app/(tabs)/mypage/store-info/page.tsx
@@ -6,6 +6,8 @@ import { Button, Header } from "@compasser/design-system";
 import type {
   StoreUpdateReqDTO,
   StoreLocationUpdateReqDTO,
+  StoreTag,
+  BankType,
 } from "@compasser/api";
 
 import StoreNameField from "@/app/signup/register/_components/fields/StoreNameField";
@@ -18,13 +20,14 @@ import PhotoUploadSection from "@/app/signup/register/_components/sections/Photo
 import TagSection from "@/app/signup/register/_components/sections/TagSection";
 import BusinessHoursModal from "@/app/signup/register/_components/modals/BusinessHoursModal";
 import RandomBoxModal from "@/app/signup/register/_components/modals/RandomBoxModal";
+import AddressSearchBottomSheet from "@/app/signup/register/_components/AddressSearchBottomSheet";
+import type { AddressSearchItem } from "@/app/signup/register/_types/address-search";
 
 import { useMyStoreQuery } from "@/shared/queries/query/useMyStoreQuery";
 import { usePatchMyStoreMutation } from "@/shared/queries/mutation/auth/usePatchMyStoreMutation";
 import { usePatchMyStoreLocationMutation } from "@/shared/queries/mutation/auth/usePatchMyStoreLocationMutation";
 import { useRandomBoxListQuery } from "@/shared/queries/query/useRandomBoxListQuery";
 import { useCreateRandomBoxMutation } from "@/shared/queries/mutation/auth/useCreateRandomBoxMutation";
-import { useUpdateRandomBoxMutation } from "@/shared/queries/mutation/auth/useUpdateRandomBoxMutation";
 import { useDeleteRandomBoxMutation } from "@/shared/queries/mutation/auth/useDeleteRandomBoxMutation";
 import { useStoreImageQuery } from "@/shared/queries/query/useStoreImageQuery";
 import { useUploadStoreImageMutation } from "@/shared/queries/mutation/auth/useUploadStoreImageMutation";
@@ -35,7 +38,21 @@ import {
   EMPTY_BUSINESS_HOURS,
 } from "@/app/signup/register/_utils/business-hours";
 
-type FixedTag = "카페" | "베이커리" | "식당";
+const tagOptions = ["카페", "베이커리", "식당"] as const;
+
+type TagLabel = (typeof tagOptions)[number];
+
+const tagMap: Record<TagLabel, StoreTag> = {
+  카페: "CAFE",
+  베이커리: "BAKERY",
+  식당: "RESTAURANT",
+};
+
+const reverseTagMap: Record<StoreTag, TagLabel> = {
+  CAFE: "카페",
+  BAKERY: "베이커리",
+  RESTAURANT: "식당",
+};
 
 export default function StoreInfoEditPage() {
   const router = useRouter();
@@ -49,7 +66,6 @@ export default function StoreInfoEditPage() {
   const patchMyStoreMutation = usePatchMyStoreMutation();
   const patchMyStoreLocationMutation = usePatchMyStoreLocationMutation();
   const createRandomBoxMutation = useCreateRandomBoxMutation();
-  const updateRandomBoxMutation = useUpdateRandomBoxMutation();
   const deleteRandomBoxMutation = useDeleteRandomBoxMutation();
   const uploadStoreImageMutation = useUploadStoreImageMutation();
   const removeStoreImageMutation = useRemoveStoreImageMutation();
@@ -57,46 +73,32 @@ export default function StoreInfoEditPage() {
   const [storeName, setStoreName] = useState("");
   const [storeEmail, setStoreEmail] = useState("");
   const [inputAddress, setInputAddress] = useState("");
-  const [bankName, setBankName] = useState("");
+  const [bankType, setBankType] = useState<BankType | "">("");
   const [depositor, setDepositor] = useState("");
   const [bankAccount, setBankAccount] = useState("");
   const [businessHours, setBusinessHours] = useState(EMPTY_BUSINESS_HOURS);
 
-  const tagOptions: FixedTag[] = ["카페", "베이커리", "식당"];
-  const [selectedTag, setSelectedTag] = useState<FixedTag | "">("");
-
-  const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>(
-    [],
-  );
-  const [isBusinessHoursModalOpen, setIsBusinessHoursModalOpen] =
-    useState(false);
+  const [selectedTag, setSelectedTag] = useState<"" | TagLabel>("");
+  const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>([]);
+  const [isBusinessHoursModalOpen, setIsBusinessHoursModalOpen] = useState(false);
   const [isRandomBoxModalOpen, setIsRandomBoxModalOpen] = useState(false);
+  const [isAddressSearchOpen, setIsAddressSearchOpen] = useState(false);
 
   const [photoFile, setPhotoFile] = useState<File | null>(null);
   const [photoPreviewUrl, setPhotoPreviewUrl] = useState("");
   const [imageRemoved, setImageRemoved] = useState(false);
 
-  const mapStoreTagToLabel = (tag: string | undefined): FixedTag | "" => {
-    switch (tag) {
-      case "CAFE":
-        return "카페";
-      case "BAKERY":
-        return "베이커리";
-      case "RESTAURANT":
-        return "식당";
-      default:
-        return "";
-    }
-  };
-
   useEffect(() => {
     if (!myStore) return;
 
     setStoreName(myStore.storeName ?? "");
-    setStoreEmail("");
+    setStoreEmail(myStore.storeEmail ?? "");
     setInputAddress(myStore.inputAddress ?? "");
     setBusinessHours(parseBusinessHours(myStore.businessHours));
-    setSelectedTag(mapStoreTagToLabel(myStore.tag));
+
+    if (myStore.tag) {
+      setSelectedTag(reverseTagMap[myStore.tag as StoreTag] ?? "");
+    }
   }, [myStore]);
 
   useEffect(() => {
@@ -105,6 +107,16 @@ export default function StoreInfoEditPage() {
   }, [storeImage, imageRemoved]);
 
   const businessHoursRows = useMemo(() => {
+    const dayKeyMap = {
+      mon: "MON",
+      tue: "TUE",
+      wed: "WED",
+      thu: "THU",
+      fri: "FRI",
+      sat: "SAT",
+      sun: "SUN",
+    } as const;
+
     const dayLabelMap = {
       mon: "월",
       tue: "화",
@@ -115,19 +127,14 @@ export default function StoreInfoEditPage() {
       sun: "일",
     } as const;
 
-    const orderedDays = [
-      "mon",
-      "tue",
-      "wed",
-      "thu",
-      "fri",
-      "sat",
-      "sun",
-    ] as const;
+    const orderedDays = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
 
     return orderedDays.map((day) => {
-      const value = businessHours[day];
-      const formatted = value === "closed" ? "휴무" : value || "-";
+      const value = businessHours.weekly[dayKeyMap[day]];
+
+      const formatted = value.closed
+        ? "휴무"
+        : `${value.open || "-"} - ${value.close || "-"}`;
 
       return {
         dayLabel: dayLabelMap[day],
@@ -135,6 +142,11 @@ export default function StoreInfoEditPage() {
       };
     });
   }, [businessHours]);
+
+  const handleSelectAddress = (item: AddressSearchItem) => {
+    setInputAddress(item.roadAddress || item.lotNumberAddress || item.label);
+    setIsAddressSearchOpen(false);
+  };
 
   const toggleRandomBoxSelection = (id: number) => {
     setSelectedRandomBoxIds((prev) =>
@@ -160,24 +172,12 @@ export default function StoreInfoEditPage() {
     price: number;
     buyLimit: number;
     content: string;
-    boxId?: number;
+    pickupTimeInfo: {
+      start: string;
+      end: string;
+    };
   }) => {
     if (!storeId) return;
-
-    if (form.boxId) {
-      await updateRandomBoxMutation.mutateAsync({
-        storeId,
-        boxId: form.boxId,
-        body: {
-          boxName: form.boxName,
-          stock: form.stock,
-          price: form.price,
-          buyLimit: form.buyLimit,
-          content: form.content,
-        },
-      });
-      return;
-    }
 
     await createRandomBoxMutation.mutateAsync({
       storeId,
@@ -187,6 +187,7 @@ export default function StoreInfoEditPage() {
         price: form.price,
         buyLimit: form.buyLimit,
         content: form.content,
+        pickupTimeInfo: form.pickupTimeInfo,
       },
     });
   };
@@ -218,10 +219,11 @@ export default function StoreInfoEditPage() {
     const storePayload: StoreUpdateReqDTO = {
       storeName,
       storeEmail,
-      bankName,
+      bankType: bankType || undefined,
       depositor,
       bankAccount,
       businessHours,
+      tag: selectedTag ? tagMap[selectedTag] : undefined,
     };
 
     const locationPayload: StoreLocationUpdateReqDTO = {
@@ -256,17 +258,18 @@ export default function StoreInfoEditPage() {
             <div className="pb-[3.6rem] pt-[1.6rem]">
               <StoreNameField value={storeName} onChange={setStoreName} />
               <EmailField value={storeEmail} onChange={setStoreEmail} />
+
               <StoreAddressField
                 value={inputAddress}
                 onChange={setInputAddress}
-                onSearchAddress={() => {}}
+                onSearchAddress={() => setIsAddressSearchOpen(true)}
               />
 
               <AccountField
-                bankName={bankName}
+                bankType={bankType}
                 depositor={depositor}
                 bankAccount={bankAccount}
-                onChangeBankName={setBankName}
+                onChangeBankType={(value) => setBankType(value as BankType)}
                 onChangeDepositor={setDepositor}
                 onChangeBankAccount={setBankAccount}
               />
@@ -293,7 +296,7 @@ export default function StoreInfoEditPage() {
               />
 
               <TagSection
-                tagOptions={tagOptions}
+                tagOptions={[...tagOptions]}
                 selectedTag={selectedTag}
                 onSelectTag={setSelectedTag}
               />
@@ -325,6 +328,12 @@ export default function StoreInfoEditPage() {
         open={isRandomBoxModalOpen}
         onClose={() => setIsRandomBoxModalOpen(false)}
         onSubmit={handleSubmitRandomBox}
+      />
+
+      <AddressSearchBottomSheet
+        open={isAddressSearchOpen}
+        onClose={() => setIsAddressSearchOpen(false)}
+        onSelectAddress={handleSelectAddress}
       />
     </>
   );

--- a/apps/owner/src/app/signup/register/_apis/searchAddressBykakao.ts
+++ b/apps/owner/src/app/signup/register/_apis/searchAddressBykakao.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import type { AddressSearchItem } from "../_types/address-search";
+
+export function searchAddressByKakao(
+  keyword: string,
+  size = 10,
+): Promise<AddressSearchItem[]> {
+  return new Promise((resolve, reject) => {
+    const trimmedKeyword = keyword.trim();
+
+    if (!trimmedKeyword) {
+      resolve([]);
+      return;
+    }
+
+    if (
+      typeof window === "undefined" ||
+      !window.kakao?.maps?.services
+    ) {
+      reject(new Error("Kakao services library is not loaded."));
+      return;
+    }
+
+    const geocoder = new window.kakao.maps.services.Geocoder();
+
+    geocoder.addressSearch(
+      trimmedKeyword,
+      (result: KakaoAddressSearchResult[], status: string) => {
+        const { kakao } = window;
+
+        if (status === kakao.maps.services.Status.ZERO_RESULT) {
+          resolve([]);
+          return;
+        }
+
+        if (status !== kakao.maps.services.Status.OK) {
+          reject(new Error("주소 검색 중 오류가 발생했습니다."));
+          return;
+        }
+
+        const mapped = result.slice(0, size).map((item, index) => {
+          const lotNumberAddress =
+            item.address?.address_name || item.address_name || "";
+
+          const roadAddress =
+            item.road_address?.address_name || item.address_name || "";
+
+          return {
+            id: `${item.x}-${item.y}-${index}`,
+            label: roadAddress || lotNumberAddress,
+            lotNumberAddress,
+            roadAddress,
+            longitude: Number(item.x),
+            latitude: Number(item.y),
+          };
+        });
+
+        resolve(mapped);
+      },
+      {
+        page: 1,
+        size,
+        analyze_type: window.kakao.maps.services.AnalyzeType.SIMILAR,
+      },
+    );
+  });
+}

--- a/apps/owner/src/app/signup/register/_components/AddressSearchBottomSheet.tsx
+++ b/apps/owner/src/app/signup/register/_components/AddressSearchBottomSheet.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { BottomSheet, Input } from "@compasser/design-system";
+import type { AddressSearchItem } from "../_types/address-search";
+import { searchAddressByKakao } from "../_apis/searchAddressBykakao";
+
+interface AddressSearchBottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onSelectAddress: (item: AddressSearchItem) => void;
+}
+
+export default function AddressSearchBottomSheet({
+  open,
+  onClose,
+  onSelectAddress,
+}: AddressSearchBottomSheetProps) {
+  const [keyword, setKeyword] = useState("");
+  const [results, setResults] = useState<AddressSearchItem[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const debounceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setKeyword("");
+      setResults([]);
+      setIsSearching(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const trimmedKeyword = keyword.trim();
+
+    if (!trimmedKeyword) {
+      setResults([]);
+      setIsSearching(false);
+      return;
+    }
+
+    if (debounceRef.current) {
+      window.clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = window.setTimeout(async () => {
+      try {
+        setIsSearching(true);
+        const searched = await searchAddressByKakao(trimmedKeyword, 10);
+        setResults(searched);
+      } catch (error) {
+        console.error(error);
+        setResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 250);
+
+    return () => {
+      if (debounceRef.current) {
+        window.clearTimeout(debounceRef.current);
+      }
+    };
+  }, [keyword, open]);
+
+  const handleSelectItem = (item: AddressSearchItem) => {
+    onSelectAddress(item);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      variant="default"
+      overlay
+      closeOnOverlayClick
+      showHandle
+      className="w-full"
+      contentClassName="px-[1.6rem] pt-[0.8rem] pb-[2rem]"
+    >
+      <Input
+        inputStyle="address"
+        value={keyword}
+        onChange={(event) => setKeyword(event.target.value)}
+        placeholder="주소를 입력해주세요"
+      />
+
+      {results.length > 0 && (
+        <div className="mt-[1.2rem] max-h-[32rem] overflow-y-auto">
+          {results.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => handleSelectItem(item)}
+              className="block w-full border-b border-gray-100 px-[0.6rem] pt-[0.8rem] pb-[1rem] text-left"
+            >
+              <p className="body2-r text-default">
+                {item.roadAddress || item.lotNumberAddress}
+              </p>
+
+              {item.roadAddress && item.lotNumberAddress && (
+                <p className="caption1-r pt-[0.2rem] text-gray-500">
+                  {item.lotNumberAddress}
+                </p>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {keyword.trim() && isSearching && (
+        <p className="caption1-r mt-[1.2rem] px-[0.6rem] text-center text-gray-500">
+          검색 중...
+        </p>
+      )}
+
+      {keyword.trim() && !isSearching && results.length === 0 && (
+        <p className="caption1-r mt-[1.2rem] px-[0.6rem] text-center text-gray-500">
+          검색 결과가 없습니다.
+        </p>
+      )}
+    </BottomSheet>
+  );
+}

--- a/apps/owner/src/app/signup/register/_components/fields/AccountField.tsx
+++ b/apps/owner/src/app/signup/register/_components/fields/AccountField.tsx
@@ -3,39 +3,40 @@
 import { useMemo, useState } from "react";
 import { Input, Tag } from "@compasser/design-system";
 import {
-  filterBankNames,
+  filterBanks,
+  getBankLabel,
   normalizeAccountNumber,
 } from "@/shared/utils/bank";
 
 type AccountStep = "bank" | "holder" | "account";
 
 interface AccountFieldProps {
-  bankName: string;
+  bankType: string;
   depositor: string;
   bankAccount: string;
-  onChangeBankName: (value: string) => void;
+  onChangeBankType: (value: string) => void;
   onChangeDepositor: (value: string) => void;
   onChangeBankAccount: (value: string) => void;
 }
 
 export default function AccountField({
-  bankName,
+  bankType,
   depositor,
   bankAccount,
-  onChangeBankName,
+  onChangeBankType,
   onChangeDepositor,
   onChangeBankAccount,
 }: AccountFieldProps) {
   const [step, setStep] = useState<AccountStep>("bank");
-  const [bankKeyword, setBankKeyword] = useState(bankName);
+  const [bankKeyword, setBankKeyword] = useState(getBankLabel(bankType));
 
   const filteredBanks = useMemo(() => {
-    return filterBankNames(bankKeyword);
+    return filterBanks(bankKeyword);
   }, [bankKeyword]);
 
   const currentValue =
     step === "bank"
-      ? bankName
+      ? bankKeyword
       : step === "holder"
         ? depositor
         : bankAccount;
@@ -49,8 +50,8 @@ export default function AccountField({
 
   const handleChangeInput = (nextValue: string) => {
     if (step === "bank") {
-      onChangeBankName(nextValue);
       setBankKeyword(nextValue);
+      onChangeBankType("");
       return;
     }
 
@@ -62,9 +63,9 @@ export default function AccountField({
     onChangeBankAccount(normalizeAccountNumber(nextValue));
   };
 
-  const handleSelectBank = (bank: string) => {
-    onChangeBankName(bank);
-    setBankKeyword(bank);
+  const handleSelectBank = (bank: { label: string; value: string }) => {
+    setBankKeyword(bank.label);
+    onChangeBankType(bank.value);
   };
 
   return (
@@ -111,13 +112,13 @@ export default function AccountField({
         <div className="mt-[0.8rem] flex flex-wrap gap-[0.6rem]">
           {filteredBanks.map((bank) => (
             <Tag
-              key={bank}
+              key={bank.value}
               variant="rounded-rect"
-              selected={bankName === bank}
+              selected={bankType === bank.value}
               changeOnClick={false}
               onClick={() => handleSelectBank(bank)}
             >
-              {bank}
+              {bank.label}
             </Tag>
           ))}
         </div>

--- a/apps/owner/src/app/signup/register/_components/modals/BusinessHoursModal.tsx
+++ b/apps/owner/src/app/signup/register/_components/modals/BusinessHoursModal.tsx
@@ -6,8 +6,10 @@ import TimeRangeField from "./TimeRangeField";
 import {
   EMPTY_BUSINESS_HOURS,
   parseBusinessHours,
+  type BusinessDayValue,
   type BusinessHoursValue,
   type DayKey,
+  type ServerDayKey,
 } from "../../_utils/business-hours";
 
 type BreakTimeOption = "yes" | "no" | null;
@@ -15,6 +17,7 @@ type BreakTimeOption = "yes" | "no" | null;
 interface BusinessHourFormValue {
   openTime: string;
   closeTime: string;
+  closed: boolean;
   hasBreakTime: BreakTimeOption;
   breakStartTime: string;
   breakEndTime: string;
@@ -27,19 +30,24 @@ interface BusinessHoursModalProps {
   onSubmit?: (data: BusinessHoursValue) => void;
 }
 
-const dayOptions: { key: DayKey; label: string }[] = [
-  { key: "mon", label: "월" },
-  { key: "tue", label: "화" },
-  { key: "wed", label: "수" },
-  { key: "thu", label: "목" },
-  { key: "fri", label: "금" },
-  { key: "sat", label: "토" },
-  { key: "sun", label: "일" },
+const dayOptions: {
+  key: DayKey;
+  serverKey: ServerDayKey;
+  label: string;
+}[] = [
+  { key: "mon", serverKey: "MON", label: "월" },
+  { key: "tue", serverKey: "TUE", label: "화" },
+  { key: "wed", serverKey: "WED", label: "수" },
+  { key: "thu", serverKey: "THU", label: "목" },
+  { key: "fri", serverKey: "FRI", label: "금" },
+  { key: "sat", serverKey: "SAT", label: "토" },
+  { key: "sun", serverKey: "SUN", label: "일" },
 ];
 
 const initialBusinessHourFormValue: BusinessHourFormValue = {
   openTime: "",
   closeTime: "",
+  closed: false,
   hasBreakTime: null,
   breakStartTime: "",
   breakEndTime: "",
@@ -52,8 +60,15 @@ const getEmptyBusinessHoursForm = (): Record<DayKey, BusinessHourFormValue> => (
   thu: { ...initialBusinessHourFormValue },
   fri: { ...initialBusinessHourFormValue },
   sat: { ...initialBusinessHourFormValue },
-  sun: { ...initialBusinessHourFormValue },
+  sun: {
+    ...initialBusinessHourFormValue,
+    closed: true,
+  },
 });
+
+const getDayOption = (day: DayKey) => {
+  return dayOptions.find((option) => option.key === day);
+};
 
 const toFormValue = (
   source?: BusinessHoursValue,
@@ -61,26 +76,46 @@ const toFormValue = (
   const normalized = parseBusinessHours(source);
   const base = getEmptyBusinessHoursForm();
 
-  (Object.keys(base) as DayKey[]).forEach((day) => {
-    const value = normalized[day];
+  dayOptions.forEach(({ key, serverKey }) => {
+    const value = normalized.weekly[serverKey];
 
-    if (!value || value === "closed") {
-      return;
-    }
-
-    const [open, close] = value.split("-");
-
-    base[day] = {
-      ...base[day],
-      openTime: open ?? "",
-      closeTime: close ?? "",
-      hasBreakTime: "no",
-      breakStartTime: "",
-      breakEndTime: "",
+    base[key] = {
+      openTime: value.open ?? "",
+      closeTime: value.close ?? "",
+      closed: value.closed,
+      hasBreakTime: value["break-time"] ? "yes" : "no",
+      breakStartTime: value["break-time"]?.start ?? "",
+      breakEndTime: value["break-time"]?.end ?? "",
     };
   });
 
   return base;
+};
+
+const toBusinessDayValue = (
+  value: BusinessHourFormValue,
+): BusinessDayValue => {
+  if (value.closed) {
+    return {
+      open: null,
+      close: null,
+      "break-time": null,
+      closed: true,
+    };
+  }
+
+  return {
+    open: value.openTime,
+    close: value.closeTime,
+    "break-time":
+      value.hasBreakTime === "yes"
+        ? {
+            start: value.breakStartTime,
+            end: value.breakEndTime,
+          }
+        : null,
+    closed: false,
+  };
 };
 
 export default function BusinessHoursModal({
@@ -105,13 +140,32 @@ export default function BusinessHoursModal({
 
   const updateSelectedDayField = (
     key: keyof BusinessHourFormValue,
-    value: string | BreakTimeOption,
+    value: string | boolean | BreakTimeOption,
   ) => {
     setBusinessHoursForm((prev) => ({
       ...prev,
       [selectedDay]: {
         ...prev[selectedDay],
         [key]: value,
+      },
+    }));
+  };
+
+  const handleChangeClosed = (closed: boolean) => {
+    setBusinessHoursForm((prev) => ({
+      ...prev,
+      [selectedDay]: {
+        ...prev[selectedDay],
+        closed,
+        ...(closed
+          ? {
+              openTime: "",
+              closeTime: "",
+              hasBreakTime: "no" as BreakTimeOption,
+              breakStartTime: "",
+              breakEndTime: "",
+            }
+          : {}),
       },
     }));
   };
@@ -137,6 +191,8 @@ export default function BusinessHoursModal({
   };
 
   const isDayCompleted = (value: BusinessHourFormValue) => {
+    if (value.closed) return true;
+
     const hasOpenClose =
       value.openTime.trim() !== "" && value.closeTime.trim() !== "";
 
@@ -157,26 +213,26 @@ export default function BusinessHoursModal({
   }, [businessHoursForm]);
 
   const isRegisterButtonEnabled = useMemo(() => {
-    return dayOptions.some((day) => completedDays[day.key]);
+    return dayOptions.every((day) => completedDays[day.key]);
   }, [completedDays]);
 
   const handleSubmit = () => {
     if (!isRegisterButtonEnabled) return;
 
-    const formatted = (Object.keys(businessHoursForm) as DayKey[]).reduce<BusinessHoursValue>(
-      (acc, day) => {
-        const value = businessHoursForm[day];
-
-        if (!isDayCompleted(value)) {
-          acc[day] = "";
-          return acc;
-        }
-
-        acc[day] = `${value.openTime}-${value.closeTime}`;
-        return acc;
+    const formatted: BusinessHoursValue = {
+      weekly: {
+        ...EMPTY_BUSINESS_HOURS.weekly,
       },
-      { ...EMPTY_BUSINESS_HOURS },
-    );
+    };
+
+    (Object.keys(businessHoursForm) as DayKey[]).forEach((day) => {
+      const dayOption = getDayOption(day);
+      if (!dayOption) return;
+
+      formatted.weekly[dayOption.serverKey] = toBusinessDayValue(
+        businessHoursForm[day],
+      );
+    });
 
     onSubmit?.(formatted);
     onClose();
@@ -195,6 +251,7 @@ export default function BusinessHoursModal({
         <div className="flex flex-wrap gap-x-[0.95rem] gap-y-[0.8rem]">
           {dayOptions.map((day) => {
             const isSelected = selectedDay === day.key;
+            const isCompleted = completedDays[day.key];
 
             return (
               <button
@@ -205,7 +262,9 @@ export default function BusinessHoursModal({
                   "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
                   isSelected
                     ? "border-primary-variant bg-primary-variant"
-                    : "border-gray-300 bg-white",
+                    : isCompleted
+                      ? "border-primary bg-white"
+                      : "border-gray-300 bg-white",
                 )}
               >
                 <span
@@ -223,87 +282,137 @@ export default function BusinessHoursModal({
 
         <div className="pt-[2.8rem]">
           <div className="flex items-center">
-            <p className="body1-r shrink-0 text-gray-700">영업시간</p>
+            <p className="body1-r shrink-0 text-gray-700">휴무 여부</p>
 
-            <TimeRangeField
-              startTime={selectedDayValue.openTime}
-              endTime={selectedDayValue.closeTime}
-              onChangeStartTime={(value) =>
-                updateSelectedDayField("openTime", value)
-              }
-              onChangeEndTime={(value) =>
-                updateSelectedDayField("closeTime", value)
-              }
-              className="ml-[5.2rem]"
-            />
+            <div className="ml-[3.8rem] flex items-center gap-[0.4rem]">
+              <button
+                type="button"
+                onClick={() => handleChangeClosed(false)}
+                className={cn(
+                  "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                  !selectedDayValue.closed
+                    ? "border-primary-variant bg-primary-variant"
+                    : "border-gray-300 bg-white",
+                )}
+              >
+                <span
+                  className={cn(
+                    "body1-r",
+                    !selectedDayValue.closed ? "text-gray-100" : "text-gray-600",
+                  )}
+                >
+                  영업
+                </span>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => handleChangeClosed(true)}
+                className={cn(
+                  "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                  selectedDayValue.closed
+                    ? "border-primary-variant bg-primary-variant"
+                    : "border-gray-300 bg-white",
+                )}
+              >
+                <span
+                  className={cn(
+                    "body1-r",
+                    selectedDayValue.closed ? "text-gray-100" : "text-gray-600",
+                  )}
+                >
+                  휴무
+                </span>
+              </button>
+            </div>
           </div>
 
-          <div className="pt-[1.6rem]">
-            <div className="flex items-center">
-              <p className="body1-r shrink-0 text-gray-700">브레이크타임</p>
+          {!selectedDayValue.closed && (
+            <>
+              <div className="flex items-center pt-[1.6rem]">
+                <p className="body1-r shrink-0 text-gray-700">영업시간</p>
 
-              <div className="ml-[2.5rem] flex items-center gap-[0.4rem]">
-                <button
-                  type="button"
-                  onClick={() => handleChangeBreakTimeOption("yes")}
-                  className={cn(
-                    "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
-                    selectedDayValue.hasBreakTime === "yes"
-                      ? "border-primary-variant bg-primary-variant"
-                      : "border-gray-300 bg-white",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "body1-r",
-                      selectedDayValue.hasBreakTime === "yes"
-                        ? "text-gray-100"
-                        : "text-gray-600",
-                    )}
-                  >
-                    유
-                  </span>
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => handleChangeBreakTimeOption("no")}
-                  className={cn(
-                    "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
-                    selectedDayValue.hasBreakTime === "no"
-                      ? "border-primary-variant bg-primary-variant"
-                      : "border-gray-300 bg-white",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "body1-r",
-                      selectedDayValue.hasBreakTime === "no"
-                        ? "text-gray-100"
-                        : "text-gray-600",
-                    )}
-                  >
-                    무
-                  </span>
-                </button>
-              </div>
-            </div>
-
-            {selectedDayValue.hasBreakTime === "yes" && (
-              <div className="pl-[10.6rem] pt-[0.8rem]">
                 <TimeRangeField
-                  startTime={selectedDayValue.breakStartTime}
-                  endTime={selectedDayValue.breakEndTime}
+                  startTime={selectedDayValue.openTime}
+                  endTime={selectedDayValue.closeTime}
                   onChangeStartTime={(value) =>
-                    updateSelectedDayField("breakStartTime", value)
+                    updateSelectedDayField("openTime", value)
                   }
                   onChangeEndTime={(value) =>
-                    updateSelectedDayField("breakEndTime", value)
+                    updateSelectedDayField("closeTime", value)
                   }
+                  className="ml-[5.2rem]"
                 />
               </div>
-            )}
-          </div>
+
+              <div className="pt-[1.6rem]">
+                <div className="flex items-center">
+                  <p className="body1-r shrink-0 text-gray-700">브레이크타임</p>
+
+                  <div className="ml-[2.5rem] flex items-center gap-[0.4rem]">
+                    <button
+                      type="button"
+                      onClick={() => handleChangeBreakTimeOption("yes")}
+                      className={cn(
+                        "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                        selectedDayValue.hasBreakTime === "yes"
+                          ? "border-primary-variant bg-primary-variant"
+                          : "border-gray-300 bg-white",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "body1-r",
+                          selectedDayValue.hasBreakTime === "yes"
+                            ? "text-gray-100"
+                            : "text-gray-600",
+                        )}
+                      >
+                        유
+                      </span>
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={() => handleChangeBreakTimeOption("no")}
+                      className={cn(
+                        "flex items-center justify-center rounded-[10px] border px-[1.2rem] py-[1rem]",
+                        selectedDayValue.hasBreakTime === "no"
+                          ? "border-primary-variant bg-primary-variant"
+                          : "border-gray-300 bg-white",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "body1-r",
+                          selectedDayValue.hasBreakTime === "no"
+                            ? "text-gray-100"
+                            : "text-gray-600",
+                        )}
+                      >
+                        무
+                      </span>
+                    </button>
+                  </div>
+                </div>
+
+                {selectedDayValue.hasBreakTime === "yes" && (
+                  <div className="pl-[10.6rem] pt-[0.8rem]">
+                    <TimeRangeField
+                      startTime={selectedDayValue.breakStartTime}
+                      endTime={selectedDayValue.breakEndTime}
+                      onChangeStartTime={(value) =>
+                        updateSelectedDayField("breakStartTime", value)
+                      }
+                      onChangeEndTime={(value) =>
+                        updateSelectedDayField("breakEndTime", value)
+                      }
+                    />
+                  </div>
+                )}
+              </div>
+            </>
+          )}
 
           <div className="pt-[1.6rem]">
             <Button

--- a/apps/owner/src/app/signup/register/_components/modals/RandomBoxModal.tsx
+++ b/apps/owner/src/app/signup/register/_components/modals/RandomBoxModal.tsx
@@ -3,12 +3,18 @@
 import { useEffect, useState } from "react";
 import { Button, Input, Modal, cn } from "@compasser/design-system";
 
+interface PickupTimeInfo {
+  start: string;
+  end: string;
+}
+
 interface RandomBoxFormValue {
   boxName: string;
   stock: number;
   price: number;
   buyLimit: number;
   content: string;
+  pickupTimeInfo: PickupTimeInfo;
   boxId?: number;
 }
 
@@ -25,6 +31,10 @@ const initialFormValue: RandomBoxFormValue = {
   price: 0,
   buyLimit: 0,
   content: "",
+  pickupTimeInfo: {
+    start: "",
+    end: "",
+  },
 };
 
 export default function RandomBoxModal({
@@ -59,11 +69,23 @@ export default function RandomBoxModal({
     }));
   };
 
+  const updatePickupTime = (key: keyof PickupTimeInfo, value: string) => {
+    setForm((prev) => ({
+      ...prev,
+      pickupTimeInfo: {
+        ...prev.pickupTimeInfo,
+        [key]: value,
+      },
+    }));
+  };
+
   const handleSubmit = async () => {
     if (!form.boxName.trim()) return;
     if (form.stock <= 0) return;
     if (form.price < 0) return;
     if (form.buyLimit <= 0) return;
+    if (!form.pickupTimeInfo.start) return;
+    if (!form.pickupTimeInfo.end) return;
 
     await onSubmit?.(form);
     onClose();
@@ -130,6 +152,32 @@ export default function RandomBoxModal({
             onChange={(event) =>
               updateField("buyLimit", Number(event.target.value || 0))
             }
+            className="w-[17rem]"
+            containerClassName="border-gray-300"
+            inputClassName="text-gray-600"
+          />
+        </div>
+
+        <div className="flex w-full items-center justify-between gap-[1.6rem]">
+          <p className="body1-r shrink-0 text-gray-700">픽업 시작 시간</p>
+
+          <Input
+            type="time"
+            value={form.pickupTimeInfo.start}
+            onChange={(event) => updatePickupTime("start", event.target.value)}
+            className="w-[17rem]"
+            containerClassName="border-gray-300"
+            inputClassName="text-gray-600"
+          />
+        </div>
+
+        <div className="flex w-full items-center justify-between gap-[1.6rem]">
+          <p className="body1-r shrink-0 text-gray-700">픽업 종료 시간</p>
+
+          <Input
+            type="time"
+            value={form.pickupTimeInfo.end}
+            onChange={(event) => updatePickupTime("end", event.target.value)}
             className="w-[17rem]"
             containerClassName="border-gray-300"
             inputClassName="text-gray-600"

--- a/apps/owner/src/app/signup/register/_types/address-search.ts
+++ b/apps/owner/src/app/signup/register/_types/address-search.ts
@@ -1,0 +1,8 @@
+export interface AddressSearchItem {
+  id: string;
+  label: string;
+  lotNumberAddress: string;
+  roadAddress: string;
+  longitude: number;
+  latitude: number;
+}

--- a/apps/owner/src/app/signup/register/_utils/business-hours.ts
+++ b/apps/owner/src/app/signup/register/_utils/business-hours.ts
@@ -1,29 +1,96 @@
 export type DayKey = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 
-export type BusinessHoursValue = Record<DayKey, string>;
+export type ServerDayKey = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+
+export interface BreakTime {
+  start: string;
+  end: string;
+}
+
+export interface BusinessDayValue {
+  open: string | null;
+  close: string | null;
+  "break-time": BreakTime | null;
+  closed: boolean;
+}
+
+export type BusinessHoursValue = {
+  weekly: Record<ServerDayKey, BusinessDayValue>;
+} & Record<string, unknown>;
+
+const createBusinessDay = (closed = false): BusinessDayValue => ({
+  open: closed ? null : "",
+  close: closed ? null : "",
+  "break-time": null,
+  closed,
+});
 
 export const EMPTY_BUSINESS_HOURS: BusinessHoursValue = {
-  mon: "",
-  tue: "",
-  wed: "",
-  thu: "",
-  fri: "",
-  sat: "",
-  sun: "",
+  weekly: {
+    MON: createBusinessDay(),
+    TUE: createBusinessDay(),
+    WED: createBusinessDay(),
+    THU: createBusinessDay(),
+    FRI: createBusinessDay(),
+    SAT: createBusinessDay(),
+    SUN: createBusinessDay(true),
+  },
+};
+
+const normalizeBreakTime = (value: unknown): BreakTime | null => {
+  if (!value || typeof value !== "object") return null;
+
+  const breakTime = value as Partial<BreakTime>;
+
+  if (typeof breakTime.start !== "string" || typeof breakTime.end !== "string") {
+    return null;
+  }
+
+  return {
+    start: breakTime.start,
+    end: breakTime.end,
+  };
+};
+
+const normalizeBusinessDay = (
+  value: unknown,
+  defaultClosed = false,
+): BusinessDayValue => {
+  if (!value || typeof value !== "object") {
+    return createBusinessDay(defaultClosed);
+  }
+
+  const day = value as Partial<BusinessDayValue>;
+
+  const closed =
+    typeof day.closed === "boolean" ? day.closed : defaultClosed;
+
+  return {
+    open: closed ? null : typeof day.open === "string" ? day.open : "",
+    close: closed ? null : typeof day.close === "string" ? day.close : "",
+    "break-time": normalizeBreakTime(day["break-time"]),
+    closed,
+  };
 };
 
 export const parseBusinessHours = (value: unknown): BusinessHoursValue => {
   if (!value || typeof value !== "object") return EMPTY_BUSINESS_HOURS;
 
-  const obj = value as Partial<Record<DayKey, unknown>>;
+  const obj = value as Partial<BusinessHoursValue>;
+
+  if (!obj.weekly || typeof obj.weekly !== "object") {
+    return EMPTY_BUSINESS_HOURS;
+  }
 
   return {
-    mon: typeof obj.mon === "string" ? obj.mon : "",
-    tue: typeof obj.tue === "string" ? obj.tue : "",
-    wed: typeof obj.wed === "string" ? obj.wed : "",
-    thu: typeof obj.thu === "string" ? obj.thu : "",
-    fri: typeof obj.fri === "string" ? obj.fri : "",
-    sat: typeof obj.sat === "string" ? obj.sat : "",
-    sun: typeof obj.sun === "string" ? obj.sun : "",
+    weekly: {
+      MON: normalizeBusinessDay(obj.weekly.MON),
+      TUE: normalizeBusinessDay(obj.weekly.TUE),
+      WED: normalizeBusinessDay(obj.weekly.WED),
+      THU: normalizeBusinessDay(obj.weekly.THU),
+      FRI: normalizeBusinessDay(obj.weekly.FRI),
+      SAT: normalizeBusinessDay(obj.weekly.SAT),
+      SUN: normalizeBusinessDay(obj.weekly.SUN, true),
+    },
   };
 };

--- a/apps/owner/src/app/signup/register/page.tsx
+++ b/apps/owner/src/app/signup/register/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import type {
   StoreUpdateReqDTO,
   StoreLocationUpdateReqDTO,
+  StoreTag,
+  BankType,
 } from "@compasser/api";
 
 import StoreNameField from "./_components/fields/StoreNameField";
@@ -19,19 +21,36 @@ import TagSection from "./_components/sections/TagSection";
 import RegisterSubmitButton from "./_components/RegisterSubmitButton";
 import BusinessHoursModal from "./_components/modals/BusinessHoursModal";
 import RandomBoxModal from "./_components/modals/RandomBoxModal";
-
+import AddressSearchBottomSheet from "./_components/AddressSearchBottomSheet";
+import type { AddressSearchItem } from "./_types/address-search";
 import { useMyStoreQuery } from "@/shared/queries/query/useMyStoreQuery";
 import { usePatchMyStoreMutation } from "@/shared/queries/mutation/auth/usePatchMyStoreMutation";
 import { usePatchMyStoreLocationMutation } from "@/shared/queries/mutation/auth/usePatchMyStoreLocationMutation";
 import { useRandomBoxListQuery } from "@/shared/queries/query/useRandomBoxListQuery";
 import { useCreateRandomBoxMutation } from "@/shared/queries/mutation/auth/useCreateRandomBoxMutation";
-import { useUpdateRandomBoxMutation } from "@/shared/queries/mutation/auth/useUpdateRandomBoxMutation";
+// import { useUpdateRandomBoxMutation } from "@/shared/queries/mutation/auth/useUpdateRandomBoxMutation";
 import { useDeleteRandomBoxMutation } from "@/shared/queries/mutation/auth/useDeleteRandomBoxMutation";
 import { useStoreImageQuery } from "@/shared/queries/query/useStoreImageQuery";
 import { useUploadStoreImageMutation } from "@/shared/queries/mutation/auth/useUploadStoreImageMutation";
 import { useRemoveStoreImageMutation } from "@/shared/queries/mutation/auth/useRemoveStoreImageMutation";
 
 import { parseBusinessHours, EMPTY_BUSINESS_HOURS } from "./_utils/business-hours";
+
+const tagOptions = ["카페", "베이커리", "식당"] as const;
+
+type TagLabel = (typeof tagOptions)[number];
+
+const tagMap: Record<TagLabel, StoreTag> = {
+  카페: "CAFE",
+  베이커리: "BAKERY",
+  식당: "RESTAURANT",
+};
+
+const reverseTagMap: Record<StoreTag, TagLabel> = {
+  CAFE: "카페",
+  BAKERY: "베이커리",
+  RESTAURANT: "식당",
+};
 
 export default function StoreRegisterPage() {
   const router = useRouter();
@@ -45,7 +64,7 @@ export default function StoreRegisterPage() {
   const patchMyStoreMutation = usePatchMyStoreMutation();
   const patchMyStoreLocationMutation = usePatchMyStoreLocationMutation();
   const createRandomBoxMutation = useCreateRandomBoxMutation();
-  const updateRandomBoxMutation = useUpdateRandomBoxMutation();
+  // const updateRandomBoxMutation = useUpdateRandomBoxMutation();
   const deleteRandomBoxMutation = useDeleteRandomBoxMutation();
   const uploadStoreImageMutation = useUploadStoreImageMutation();
   const removeStoreImageMutation = useRemoveStoreImageMutation();
@@ -53,13 +72,13 @@ export default function StoreRegisterPage() {
   const [storeName, setStoreName] = useState("");
   const [storeEmail, setStoreEmail] = useState("");
   const [inputAddress, setInputAddress] = useState("");
-  const [bankName, setBankName] = useState("");
+  const [bankType, setBankType] = useState<BankType | "">("");
+  const [isAddressSearchOpen, setIsAddressSearchOpen] = useState(false);
   const [depositor, setDepositor] = useState("");
   const [bankAccount, setBankAccount] = useState("");
   const [businessHours, setBusinessHours] = useState(EMPTY_BUSINESS_HOURS);
 
-  const tagOptions = ["카페", "베이커리", "식당"] as const;
-  const [selectedTag, setSelectedTag] = useState<"" | "카페" | "베이커리" | "식당">("");
+  const [selectedTag, setSelectedTag] = useState<"" | TagLabel>("");
   const [selectedRandomBoxIds, setSelectedRandomBoxIds] = useState<number[]>([]);
   const [isBusinessHoursModalOpen, setIsBusinessHoursModalOpen] = useState(false);
   const [isRandomBoxModalOpen, setIsRandomBoxModalOpen] = useState(false);
@@ -69,12 +88,16 @@ export default function StoreRegisterPage() {
   const [imageRemoved, setImageRemoved] = useState(false);
 
   useEffect(() => {
-    if (!myStore) return;
+  if (!myStore) return;
 
     setStoreName(myStore.storeName ?? "");
-    setStoreEmail("");
+    setStoreEmail(myStore.storeEmail ?? "");
     setInputAddress(myStore.inputAddress ?? "");
     setBusinessHours(parseBusinessHours(myStore.businessHours));
+
+    if (myStore.tag) {
+      setSelectedTag(reverseTagMap[myStore.tag as StoreTag] ?? "");
+    }
   }, [myStore]);
 
   useEffect(() => {
@@ -83,6 +106,16 @@ export default function StoreRegisterPage() {
   }, [storeImage, imageRemoved]);
 
   const businessHoursRows = useMemo(() => {
+    const dayKeyMap = {
+      mon: "MON",
+      tue: "TUE",
+      wed: "WED",
+      thu: "THU",
+      fri: "FRI",
+      sat: "SAT",
+      sun: "SUN",
+    } as const;
+
     const dayLabelMap = {
       mon: "월",
       tue: "화",
@@ -96,8 +129,11 @@ export default function StoreRegisterPage() {
     const orderedDays = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
 
     return orderedDays.map((day) => {
-      const value = businessHours[day];
-      const formatted = value === "closed" ? "휴무" : value || "-";
+      const value = businessHours.weekly[dayKeyMap[day]];
+
+      const formatted = value.closed
+        ? "휴무"
+        : `${value.open || "-"} - ${value.close || "-"}`;
 
       return {
         dayLabel: dayLabelMap[day],
@@ -106,9 +142,14 @@ export default function StoreRegisterPage() {
     });
   }, [businessHours]);
 
+  const handleSelectAddress = (item: AddressSearchItem) => {
+    setInputAddress(item.roadAddress || item.lotNumberAddress || item.label);
+    setIsAddressSearchOpen(false);
+  };
+
   const toggleRandomBoxSelection = (id: number) => {
     setSelectedRandomBoxIds((prev) =>
-      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
     );
   };
 
@@ -117,8 +158,8 @@ export default function StoreRegisterPage() {
 
     await Promise.all(
       selectedRandomBoxIds.map((boxId) =>
-        deleteRandomBoxMutation.mutateAsync({ storeId, boxId })
-      )
+        deleteRandomBoxMutation.mutateAsync({ storeId, boxId }),
+      ),
     );
 
     setSelectedRandomBoxIds([]);
@@ -130,34 +171,35 @@ export default function StoreRegisterPage() {
     price: number;
     buyLimit: number;
     content: string;
+    pickupTimeInfo: {
+      start: string;
+      end: string;
+    };
     boxId?: number;
   }) => {
     if (!storeId) return;
 
-    if (form.boxId) {
-      await updateRandomBoxMutation.mutateAsync({
-        storeId,
-        boxId: form.boxId,
-        body: {
-          boxName: form.boxName,
-          stock: form.stock,
-          price: form.price,
-          buyLimit: form.buyLimit,
-          content: form.content,
-        },
-      });
-      return;
-    }
+    const body = {
+      boxName: form.boxName,
+      stock: form.stock,
+      price: form.price,
+      buyLimit: form.buyLimit,
+      content: form.content,
+      pickupTimeInfo: form.pickupTimeInfo,
+    };
+
+    // if (form.boxId) {
+    //   await updateRandomBoxMutation.mutateAsync({
+    //     storeId,
+    //     boxId: form.boxId,
+    //     body,
+    //   });
+    //   return;
+    // }
 
     await createRandomBoxMutation.mutateAsync({
       storeId,
-      body: {
-        boxName: form.boxName,
-        stock: form.stock,
-        price: form.price,
-        buyLimit: form.buyLimit,
-        content: form.content,
-      },
+      body,
     });
   };
 
@@ -188,10 +230,11 @@ export default function StoreRegisterPage() {
     const storePayload: StoreUpdateReqDTO = {
       storeName,
       storeEmail,
-      bankName,
+      bankType: bankType || undefined,
       depositor,
       bankAccount,
       businessHours,
+      tag: selectedTag ? tagMap[selectedTag] : undefined,
     };
 
     const locationPayload: StoreLocationUpdateReqDTO = {
@@ -222,13 +265,14 @@ export default function StoreRegisterPage() {
             <StoreAddressField
               value={inputAddress}
               onChange={setInputAddress}
-              onSearchAddress={() => {}}
+              onSearchAddress={() => setIsAddressSearchOpen(true)}
             />
+
             <AccountField
-              bankName={bankName}
+              bankType={bankType}
               depositor={depositor}
               bankAccount={bankAccount}
-              onChangeBankName={setBankName}
+              onChangeBankType={(value) => setBankType(value as BankType)}
               onChangeDepositor={setDepositor}
               onChangeBankAccount={setBankAccount}
             />
@@ -274,6 +318,12 @@ export default function StoreRegisterPage() {
         open={isRandomBoxModalOpen}
         onClose={() => setIsRandomBoxModalOpen(false)}
         onSubmit={handleSubmitRandomBox}
+      />
+
+      <AddressSearchBottomSheet
+        open={isAddressSearchOpen}
+        onClose={() => setIsAddressSearchOpen(false)}
+        onSelectAddress={handleSelectAddress}
       />
     </>
   );

--- a/apps/owner/src/shared/types/kakao.d.ts
+++ b/apps/owner/src/shared/types/kakao.d.ts
@@ -1,0 +1,116 @@
+export {};
+
+declare global {
+  interface Window {
+    kakao: {
+      maps: {
+        load: (callback: () => void) => void;
+
+        LatLng: new (latitude: number, longitude: number) => KakaoLatLng;
+
+        Map: new (
+          container: HTMLElement,
+          options: {
+            center: KakaoLatLng;
+            level: number;
+          }
+        ) => KakaoMapInstance;
+
+        Marker: new (options: {
+          map?: KakaoMapInstance | null;
+          position: KakaoLatLng;
+          title?: string;
+          image?: KakaoMarkerImage;
+        }) => KakaoMarker;
+
+        MarkerImage: new (
+          src: string,
+          size: KakaoSize,
+          options?: {
+            offset?: KakaoPoint;
+            alt?: string;
+            shape?: string;
+            coords?: string;
+            spriteOrigin?: KakaoPoint;
+            spriteSize?: KakaoSize;
+          }
+        ) => KakaoMarkerImage;
+
+        Size: new (width: number, height: number) => KakaoSize;
+
+        Point: new (x: number, y: number) => KakaoPoint;
+
+        event: {
+          addListener: (
+            target: object,
+            type: string,
+            handler: (...args: unknown[]) => void
+          ) => void;
+          removeListener: (
+            target: object,
+            type: string,
+            handler: (...args: unknown[]) => void
+          ) => void;
+        };
+
+        services: {
+          Geocoder: new () => {
+            addressSearch: (
+              address: string,
+              callback: (
+                result: KakaoAddressSearchResult[],
+                status: string
+              ) => void,
+              options?: {
+                page?: number;
+                size?: number;
+                analyze_type?: string;
+              }
+            ) => void;
+          };
+
+          Status: {
+            OK: string;
+            ZERO_RESULT: string;
+            ERROR: string;
+          };
+
+          AnalyzeType: {
+            SIMILAR: string;
+            EXACT: string;
+          };
+        };
+      };
+    };
+  }
+
+  interface KakaoLatLng {}
+
+  interface KakaoMapInstance {
+    relayout: () => void;
+    setCenter: (latlng: KakaoLatLng) => void;
+  }
+
+  interface KakaoMarker {
+    setMap: (map: KakaoMapInstance | null) => void;
+    setPosition: (position: KakaoLatLng) => void;
+  }
+
+  interface KakaoMarkerImage {}
+
+  interface KakaoSize {}
+
+  interface KakaoPoint {}
+
+  interface KakaoAddressSearchResult {
+    address_name: string;
+    x: string;
+    y: string;
+    address?: {
+      address_name: string;
+    };
+    road_address?: {
+      address_name: string;
+    };
+  }
+}

--- a/apps/owner/src/shared/utils/bank.ts
+++ b/apps/owner/src/shared/utils/bank.ts
@@ -1,26 +1,34 @@
-export const bankNameOptions = [
-  "국민은행",
-  "신한은행",
-  "우리은행",
-  "하나은행",
-  "농협은행",
-  "기업은행",
-  "카카오뱅크",
-  "토스뱅크",
-  "케이뱅크",
-  "새마을금고",
-  "수협은행",
-  "부산은행",
-  "대구은행",
-  "광주은행",
-  "전북은행",
-  "경남은행",
+export const bankOptions = [
+  { label: "국민은행", value: "KB" },
+  { label: "신한은행", value: "SHINHAN" },
+  { label: "우리은행", value: "WOORI" },
+  { label: "하나은행", value: "HANA" },
+  { label: "농협은행", value: "NH" },
+  { label: "기업은행", value: "IBK" },
+  { label: "카카오뱅크", value: "KAKAO" },
+  { label: "토스뱅크", value: "TOSS" },
+  { label: "케이뱅크", value: "K" },
+  { label: "새마을금고", value: "SAEMAUL" },
+  { label: "수협은행", value: "SUHYUP" },
+  { label: "부산은행", value: "BUSAN" },
+  { label: "대구은행", value: "DAEGU" },
+  { label: "광주은행", value: "GWANGJU" },
+  { label: "전북은행", value: "JEONBUK" },
+  { label: "경남은행", value: "KYONGNAM" },
 ] as const;
 
-export const filterBankNames = (keyword: string) => {
+export type BankLabel = (typeof bankOptions)[number]["label"];
+export type BankValue = (typeof bankOptions)[number]["value"];
+
+export const filterBanks = (keyword: string) => {
   const normalized = keyword.trim();
-  if (!normalized) return bankNameOptions;
-  return bankNameOptions.filter((bank) => bank.includes(normalized));
+  if (!normalized) return bankOptions;
+
+  return bankOptions.filter((bank) => bank.label.includes(normalized));
+};
+
+export const getBankLabel = (value: string) => {
+  return bankOptions.find((bank) => bank.value === value)?.label ?? "";
 };
 
 export const normalizeAccountNumber = (value: string) => {

--- a/packages/api/src/models/random-box.ts
+++ b/packages/api/src/models/random-box.ts
@@ -1,3 +1,4 @@
+import { JsonValue } from "../core/types";
 import type { SaleStatus } from "./common";
 
 export interface RandomBoxCreateReqDTO {
@@ -6,6 +7,7 @@ export interface RandomBoxCreateReqDTO {
   stock?: number;
   price?: number;
   buyLimit?: number;
+  pickupTimeInfo?: JsonValue;
 }
 
 export interface RandomBoxUpdateReqDTO extends RandomBoxCreateReqDTO {
@@ -20,5 +22,6 @@ export interface RandomBoxRespDTO {
   price: number;
   buyLimit: number;
   content: string;
-  saleStatus: string;
+  saleStatus: SaleStatus | string;
+  pickupTimeInfo: string;
 }

--- a/packages/api/src/models/store.ts
+++ b/packages/api/src/models/store.ts
@@ -4,10 +4,11 @@ import type { StoreTag } from "./common";
 export interface StoreUpdateReqDTO {
   storeName?: string;
   storeEmail?: string;
-  bankName?: string;
+  bankType?: string;
   depositor?: string;
   bankAccount?: string;
   businessHours?: JsonValue;
+  tag?: StoreTag;
 }
 
 export interface StoreLocationUpdateReqDTO {
@@ -66,9 +67,9 @@ export interface SimpleStoreInfoDTO {
   storeId: number;
   tag: StoreTag;
   storeName: string;
-  storeEmail: string;
   roadAddress: string;
   jibunAddress: string;
+  storeEmail: string;
   businessHours?: JsonValue;
 }
 


### PR DESCRIPTION
## ✅ 작업 내용
#### 📝 Description
> 점주 스토어 등록/수정 페이지 API 연동 및 데이터 구조 정합성 개선

- [x] 내 가게 조회/수정 API 연동
- [x] 가게 위치 수정 API 연동
- [x] 랜덤박스 조회/등록/삭제 API 연동
- [x] 대표 이미지 조회/업로드/삭제 API 연동
- [x] 카카오 주소 검색 BottomSheet 연동
- [x] businessHours / bankType 서버 스펙 반영

## 🚀 설계 의도 및 개선점
> 프론트 상태 구조를 Swagger 응답/요청 스펙과 일치시키고, 등록/수정 페이지가 동일한 흐름으로 동작하도록 통일했습니다.

- businessHours를 `weekly(MON~SUN)` 구조로 리팩토링
- 은행명 UI와 `bankType enum` 서버 값 분리 처리
- 주소 검색을 공통 BottomSheet로 분리해 재사용성 확보
- 랜덤박스 수정 로직 제거 후 `조회/추가/삭제` 중심으로 단순화
- register / store-info 페이지 상태 및 API 처리 구조 통일

### 📎 기타 참고사항
- 기존 mock 기반 입력값 → 실제 API 응답 기반 초기값 반영
- Kakao services script 필요

Fixes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 주소 검색 기능 추가 - 하단 시트에서 주소를 검색하고 선택할 수 있습니다.
  * 랜덤박스 픽업 시간 설정 - 시작 및 종료 시간을 지정할 수 있습니다.
  * 매장 태그 관리 시스템 추가

* **Improvements**
  * 매장 정보 편집 페이지 기능 개선
  * 영업시간 관리 구조 업데이트
  * 은행 정보 처리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->